### PR TITLE
Added option to write out data in stokes I only instead of IQUV

### DIFF
--- a/app/make_mwa_tied_array_beam.c
+++ b/app/make_mwa_tied_array_beam.c
@@ -576,12 +576,12 @@ void make_tied_array_beam_parse_cmdline(
                     break;
                 case 'N':
                     opts->out_nstokes = atoi(optarg);
-                    //if ((opts->out_nstokes != 1) || (opts->out_nstokes != 4))
-                    //{
-                    //    fprintf( stderr, "error: make_tied_array_beam_parse_cmdline: "
-                    //            "-%c argument must be either 1 or 4", c );
-                    //    exit(EXIT_FAILURE);
-                    //}
+                    if ((opts->out_nstokes != 1) && (opts->out_nstokes != 4))
+                    {
+                        fprintf( stderr, "error: make_tied_array_beam_parse_cmdline: "
+                                "-%c argument must be either 1 or 4", c );
+                        exit(EXIT_FAILURE);
+                    }
                     break;
                 case 'O':
                     opts->cal_type = CAL_OFFRINGA;

--- a/app/make_mwa_tied_array_beam.c
+++ b/app/make_mwa_tied_array_beam.c
@@ -576,12 +576,12 @@ void make_tied_array_beam_parse_cmdline(
                     break;
                 case 'N':
                     opts->out_nstokes = atoi(optarg);
-                    if ((opts->out_nstokes != 1) || (opts->out_nstokes != 4))
-                    {
-                        fprintf( stderr, "error: make_tied_array_beam_parse_cmdline: "
-                                "-%c argument must be either 1 or 4", c );
-                        exit(EXIT_FAILURE);
-                    }
+                    //if ((opts->out_nstokes != 1) || (opts->out_nstokes != 4))
+                    //{
+                    //    fprintf( stderr, "error: make_tied_array_beam_parse_cmdline: "
+                    //            "-%c argument must be either 1 or 4", c );
+                    //    exit(EXIT_FAILURE);
+                    //}
                     break;
                 case 'O':
                     opts->cal_type = CAL_OFFRINGA;

--- a/app/make_mwa_tied_array_beam.c
+++ b/app/make_mwa_tied_array_beam.c
@@ -35,6 +35,7 @@ struct make_tied_array_beam_opts {
     // Output options
     bool               out_fine;         // Output fine channelised data (PSRFITS)
     bool               out_coarse;       // Output coarse channelised data (VDIF)
+    int                out_nstokes;      // Number of stokes parameters in PSRFITS output
 
     // Calibration options
     char              *cal_metafits;     // Filename of the metafits file
@@ -100,8 +101,10 @@ int main(int argc, char **argv)
         vmSetOutputChannelisation( vm, opts.out_fine, opts.out_coarse );
     }
 
-    // If we need to, set up the forward PFB
+    // Set up case for stokes output and number of chunks per second of data
+    vm->out_nstokes = opts.out_nstokes;
     vm->chunks_per_second = opts.nchunks;
+    // If we need to, set up the forward PFB
     if (vm->do_forward_pfb)
     {
         // Load the filter
@@ -200,7 +203,7 @@ int main(int argc, char **argv)
     {
         for (p = 0; p < vm->npointing; p++)
         {
-            vmInitMPIPsrfits( vm, &(mpfs[p]), opts.max_sec_per_file, NSTOKES,
+            vmInitMPIPsrfits( vm, &(mpfs[p]), opts.max_sec_per_file, opts.out_nstokes,
                     &(beam_geom_vals[p]), NULL, true );
         }
     }
@@ -411,6 +414,7 @@ void usage()
     printf( "\nOUTPUT OPTIONS\n\n"
             "\t-p, --out-fine             Output fine-channelised, full-Stokes data (PSRFITS)\n"
             "\t                           (if neither -p nor -v are used, default behaviour is to match channelisation of input)\n"
+            "\t-N, --out-nstokes          Number of stokes parameters to output. Either 1 (stokes I only) or 4 (stokes IQUV)\n"
             "\t-t, --max_t                Maximum number of seconds per output FITS file. [default: 200]\n"
             "\t-v, --out-coarse           Output coarse-channelised, 2-pol (XY) data (VDIF)\n"
             "\t                           (if neither -p nor -v are used, default behaviour is to match channelisation of input)\n"
@@ -465,6 +469,7 @@ void make_tied_array_beam_parse_cmdline(
     opts->coarse_chan_str      = NULL;  // Absolute or relative coarse channel
     opts->out_fine             = false; // Output fine channelised data (PSRFITS)
     opts->out_coarse           = false; // Output coarse channelised data (VDIF)
+    opts->out_nstokes          = 4;     // Output stokes IQUV by default
     opts->analysis_filter      = NULL;
     opts->synth_filter         = NULL;
     opts->max_sec_per_file     = 200;   // Number of seconds per fits files
@@ -493,6 +498,7 @@ void make_tied_array_beam_parse_cmdline(
                 {"bandpass",        no_argument,       0, 'B'},
                 {"out-fine",        no_argument,       0, 'p'},
                 {"out-coarse",      no_argument,       0, 'v'},
+                {"out-nstokes",     no_argument,       0, 'N'},
                 {"max_t",           required_argument, 0, 't'},
                 {"analysis_filter", required_argument, 0, 'A'},
                 {"synth_filter",    required_argument, 0, 'S'},
@@ -567,6 +573,15 @@ void make_tied_array_beam_parse_cmdline(
                     break;
                 case 'n':
                     opts->nchunks = atoi(optarg);
+                    break;
+                case 'N':
+                    opts->out_nstokes = atoi(optarg);
+                    if ((opts->out_nstokes != 1) || (opts->out_nstokes != 4))
+                    {
+                        fprintf( stderr, "error: make_tied_array_beam_parse_cmdline: "
+                                "-%c argument must be either 1 or 4", c );
+                        exit(EXIT_FAILURE);
+                    }
                     break;
                 case 'O':
                     opts->cal_type = CAL_OFFRINGA;

--- a/app/make_mwa_tied_array_beam.c
+++ b/app/make_mwa_tied_array_beam.c
@@ -523,7 +523,7 @@ void make_tied_array_beam_parse_cmdline(
 
             int option_index = 0;
             c = getopt_long( argc, argv,
-                             "A:b:Bc:C:d:e:f:F:hm:n:OpP:R:sS:t:T:U:vVX",
+                             "A:b:Bc:C:d:e:f:F:hm:nN:OpP:R:sS:t:T:U:vVX",
                              long_options, &option_index);
             if (c == -1)
                 break;

--- a/include/vcsbeam.h.in
+++ b/include/vcsbeam.h.in
@@ -630,6 +630,9 @@ typedef struct vcsbeam_context_t
     int nchan;                        // Number of channels
     int nfine_chan;                   // Number of fine channels
 
+    // Output number of stokes parameters needed
+    int out_nstokes;
+
     // VDIF output
     vdif_header      vhdr;
     struct vdifinfo *vf;

--- a/src/form_beam.cu
+++ b/src/form_beam.cu
@@ -244,7 +244,7 @@ __global__ void vmBeamform_kernel( cuDoubleComplex *Jv_Q,
                                  cuDoubleComplex *e,
                                  float *S,
                                  int npol,
-                                 int nstokes)
+                                 int nstokes )
 {
     // Translate GPU block/thread numbers into meaningful names
     int c    = blockIdx.x;  /* The (c)hannel number */
@@ -564,7 +564,7 @@ void vmBeamformChunk( vcsbeam_context *vm )
                 vm->chunks_per_second,
                 vm->d_e,
                 (float *)vm->d_S,
-                vm->obs_metadata->num_ant_pols
+                vm->obs_metadata->num_ant_pols,
                 vm->out_nstokes );
 
         cudaCheckErrors( "vmBeamformChunk: vmBeamform_kernel failed" );

--- a/src/form_beam.cu
+++ b/src/form_beam.cu
@@ -243,7 +243,8 @@ __global__ void vmBeamform_kernel( cuDoubleComplex *Jv_Q,
                                  int nchunk,
                                  cuDoubleComplex *e,
                                  float *S,
-                                 int npol )
+                                 int npol,
+                                 int nstokes)
 {
     // Translate GPU block/thread numbers into meaningful names
     int c    = blockIdx.x;  /* The (c)hannel number */
@@ -563,7 +564,8 @@ void vmBeamformChunk( vcsbeam_context *vm )
                 vm->chunks_per_second,
                 vm->d_e,
                 (float *)vm->d_S,
-                vm->obs_metadata->num_ant_pols );
+                vm->obs_metadata->num_ant_pols
+                vm->out_nstokes);
 
         cudaCheckErrors( "vmBeamformChunk: vmBeamform_kernel failed" );
     }

--- a/src/form_beam.cu
+++ b/src/form_beam.cu
@@ -565,7 +565,7 @@ void vmBeamformChunk( vcsbeam_context *vm )
                 vm->d_e,
                 (float *)vm->d_S,
                 vm->obs_metadata->num_ant_pols
-                vm->out_nstokes);
+                vm->out_nstokes );
 
         cudaCheckErrors( "vmBeamformChunk: vmBeamform_kernel failed" );
     }

--- a/src/metadata.c
+++ b/src/metadata.c
@@ -501,7 +501,7 @@ void vmMallocEHost( vcsbeam_context *vm )
  */
 void vmMallocSHost( vcsbeam_context *vm )
 {
-    vm->S_size_bytes = vm->npointing * vm->nfine_chan * NSTOKES * vm->fine_sample_rate * sizeof(float);
+    vm->S_size_bytes = vm->npointing * vm->nfine_chan * vm->out_nstokes * vm->fine_sample_rate * sizeof(float);
 
     // Allocate memory on host
     cudaMallocHost( (void **)&(vm->S), vm->S_size_bytes );
@@ -738,7 +738,7 @@ void vmMallocEDevice( vcsbeam_context *vm )
  */
 void vmMallocSDevice( vcsbeam_context *vm )
 {
-    vm->d_S_size_bytes = vm->npointing * vm->nfine_chan * NSTOKES * vm->fine_sample_rate * sizeof(float);
+    vm->d_S_size_bytes = vm->npointing * vm->nfine_chan * vm->out_nstokes * vm->fine_sample_rate * sizeof(float);
 
     // Allocate memory on device
     cudaMalloc( (void **)&(vm->d_S), vm->d_S_size_bytes );
@@ -1098,8 +1098,8 @@ void vmCreateStatistics( vcsbeam_context *vm, mpi_psrfits *mpfs )
 {
     uintptr_t nchan  = vm->nfine_chan;
 
-    vm->offsets_size = vm->npointing*nchan*NSTOKES*sizeof(float);
-    vm->scales_size  = vm->npointing*nchan*NSTOKES*sizeof(float);
+    vm->offsets_size = vm->npointing*nchan*vm->out_nstokes*sizeof(float);
+    vm->scales_size  = vm->npointing*nchan*vm->out_nstokes*sizeof(float);
     vm->Cscaled_size = vm->npointing*mpfs[0].coarse_chan_pf.sub.bytes_per_subint;
 
     cudaMalloc( (void **)&vm->d_offsets, vm->offsets_size );
@@ -1154,7 +1154,7 @@ void vmSetNumPointings( vcsbeam_context *vm, unsigned int npointings )
 {
     uintptr_t npol      = vm->obs_metadata->num_ant_pols; // = 2
     vm->npointing       = npointings;
-    vm->S_size_bytes    = vm->npointing * vm->nchan * NSTOKES * vm->sample_rate * sizeof(float);
+    vm->S_size_bytes    = vm->npointing * vm->nchan * vm->out_nstokes * vm->sample_rate * sizeof(float);
     vm->d_S_size_bytes  = vm->S_size_bytes;
     vm->e_size_bytes    = vm->npointing * vm->sample_rate * vm->nchan * npol * sizeof(cuDoubleComplex);
     vm->d_e_size_bytes  = vm->e_size_bytes;


### PR DESCRIPTION
I think these are all I need to change to make things work. As far as I can see, the nstokes parameters only affects what kind of output do we want to write into the psrfits files. I made them take in the value input by the tied array beam script instead of a default value in the include file.