### PR TITLE
Fix picket-fence frequency mislabelling in PSRFITS output

### DIFF
--- a/src/beam_psrfits.c
+++ b/src/beam_psrfits.c
@@ -79,6 +79,16 @@ void populate_spliced_psrfits_header(
     strcpy( pf->hdr.frontend,  "MWA-RECVR" );
     snprintf( pf->hdr.source, 24, "%u", vm->obs_metadata->obs_id );
     snprintf( pf->hdr.backend, 24, "%s", VCSBEAM_VERSION );
+    /* TODO: We should change the backend to one of the following,
+     * to match what is included in PRESTO for MWA SIGPROC-style data:
+     *    MWA-VCS (Legacy system, retired Aug 2021)
+     *    MWAX-VCS (Current system, began Oct 2021)
+     * Is this information available from within the metafits data?
+     * In which case, it should be a simple query and case statement.
+     * Since PSRFITS does not appear to naturally support a HISTORY
+     * table in its header, we may also have to have the VCSBEAM_VERSION
+     * appended to the end of the backend label?
+     */
 
     // Now let us finally get the time right
     strcpy(pf->hdr.date_obs,   time_utc);
@@ -300,15 +310,16 @@ void populate_psrfits_header(
 
     snprintf( pf->hdr.source, 24, "%u", vm->obs_metadata->obs_id );
     snprintf( pf->hdr.backend, 24, "%s", VCSBEAM_VERSION );
-    // TODO: We should change the backend to one of the following,
-    // to match what is included in PRESTO for MWA SIGPROC-style data:
-    //      MWA-VCS (Legacy system, retired Aug 2021)
-    //      MWAX-VCS (Current system, began Oct 2021)
-    // Is this information available from within the metafits data?
-    // In which case, it should be a simple query and case statement.
-    // Since PSRFITS does not appear to naturally support a HISTORY
-    // table in its header, we may also have to have the VCSBEAM_VERSION
-    // appended to the end of the backend label?
+    /* TODO: We should change the backend to one of the following,
+     * to match what is included in PRESTO for MWA SIGPROC-style data:
+     *    MWA-VCS (Legacy system, retired Aug 2021)
+     *    MWAX-VCS (Current system, began Oct 2021)
+     * Is this information available from within the metafits data?
+     * In which case, it should be a simple query and case statement.
+     * Since PSRFITS does not appear to naturally support a HISTORY
+     * table in its header, we may also have to have the VCSBEAM_VERSION
+     * appended to the end of the backend label?
+     */
 
     pf->hdr.scanlen = 1.0; // in sec
 

--- a/src/beam_psrfits.c
+++ b/src/beam_psrfits.c
@@ -61,6 +61,19 @@ void populate_spliced_psrfits_header(
     int coarse_chan_idx = vm->vcs_metadata->provided_coarse_chan_indices[0];
     int first_coarse_chan_idx = coarse_chan_idx - vm->mpi_rank;
 
+    sprintf( vm->log_message, "DEBUG [beam_psrfits.c]: I think the coarse channel index (vcs_metadata) is: %d", coarse_chan_idx );
+    logger_timed_message( vm->log, vm->log_message );
+    sprintf( vm->log_message, "DEBUG [beam_psrfits.c]: I think the first coarse channel index (MPI) is: %d", first_coarse_chan_idx );
+    logger_timed_message( vm->log, vm->log_message );
+    fprintf(stderr, "listing coarse chan idxs\n");
+    unsigned int ci = 0;
+    int cci = 0;
+    for(ci; ci<vm->obs_metadata->num_metafits_coarse_chans; ci++)
+    {
+        cci = vm->vcs_metadata->provided_coarse_chan_indices[ci];
+        fprintf(stderr, "%d\n", cci);
+    }
+
     // Now set values for our hdrinfo structure
     strcpy( pf->hdr.project_id, vm->obs_metadata->project_id );
     strcpy( pf->hdr.obs_mode,  "SEARCH"    );
@@ -152,11 +165,14 @@ void populate_spliced_psrfits_header(
     // actual first coarse channel of the current data context. For contiguous data,
     // this will be equivalent to the zeroth entry in the metafits data.
     uint32_t start_hz = vm->obs_metadata->metafits_coarse_chans[first_coarse_chan_idx].chan_start_hz;
+    fprintf( stderr, "DEBUG [%s, %d]: I think the start frequency in hz is: %u\n", __FILE__, __LINE__, start_hz );
+
     for (i = 0 ; i < pf->hdr.nchan; i++)
     {
         iC = i / vm->nfine_chan + first_coarse_chan_idx;
         iF = (iC * vm->nfine_chan) + (i % vm->nfine_chan);
-        pf->sub.dat_freqs[i] = (start_hz + iF*fine_chan_width)*1e-6;
+        pf->sub.dat_freqs[i] = (float) ((double) (start_hz + iF*fine_chan_width)*1e-6);
+        fprintf( stderr, "DEBUG [%s, %d]: added frequency to header: %f\n", __FILE__, __LINE__, pf->sub.dat_freqs[i] );
         pf->sub.dat_weights[i] = 1.0;
     }
 


### PR DESCRIPTION
Resolves #27 

I believe this fixes the problem of incorrect frequency labels in the subint DAT_FREQ tables and does not change the behaviour of contiguous-band VCSBeam processing. 

