### PR TITLE
VDIF Handling Updates

### DIFF
--- a/app/make_mwa_tied_array_beam.c
+++ b/app/make_mwa_tied_array_beam.c
@@ -137,9 +137,10 @@ int main(int argc, char **argv)
 
     // Calculate the actual start time of the dataset to be processed
     unsigned int p;
-    double mjd, sec_offset;
+    double mjd, mjd_start, sec_offset;
     sec_offset = vm->gps_seconds_to_process[0] - (vm->obs_metadata->sched_start_gps_time_ms / 1000.0);
-    mjd = vm->obs_metadata->sched_start_mjd + (sec_offset / 86400.0);
+    mjd_start = vm->obs_metadata->sched_start_mjd;
+    mjd = mjd_start + (sec_offset / 86400.0);
     
     for (p = 0; p < vm->npointing; p++)
         calc_beam_geom( vm->ras_hours[p], vm->decs_degs[p], mjd, &beam_geom_vals[p] );
@@ -233,7 +234,7 @@ int main(int argc, char **argv)
     // ------------------
 
     // Populate the relevant header structs
-    vmPopulateVDIFHeader( vm, beam_geom_vals );
+    vmPopulateVDIFHeader( vm, beam_geom_vals, mjd_start, sec_offset );
 
     // Begin the main loop: go through data one second at a time
 

--- a/app/make_mwa_tied_array_beam.c
+++ b/app/make_mwa_tied_array_beam.c
@@ -275,7 +275,7 @@ int main(int argc, char **argv)
 
             vmPullE( vm );
 
-            prepare_detected_beam( detected_beam, mpfs, vm );
+            prepare_detected_beam( detected_beam, mpfs, vm, timestep_idx );
             cu_invert_pfb( detected_beam, timestep_idx, vm->npointing,
                     nsamples, nchans, npols, vm->vf->sizeof_buffer,
                     &gi, data_buffer_vdif );

--- a/include/vcsbeam.h.in
+++ b/include/vcsbeam.h.in
@@ -968,7 +968,7 @@ struct gpu_ipfb_arrays
 extern "C" {
 #endif
 
-void cu_invert_pfb( cuDoubleComplex ****detected_beam, int file_no,
+void cu_invert_pfb( cuDoubleComplex *data_buffer_fine, int file_no,
                         int npointing, int nsamples, int nchan, int npol, int sizeof_buffer,
                         struct gpu_ipfb_arrays *g, float *data_buffer_uvdif );
 
@@ -1026,9 +1026,8 @@ void vmBeamformSecond( vcsbeam_context *vm );
 void vmPullE( vcsbeam_context *vm );
 void vmPullS( vcsbeam_context *vm );
 
-void prepare_detected_beam( cuDoubleComplex ****detected_beam,
-                   mpi_psrfits *mpfs, vcsbeam_context *vm,
-                   uintptr_t timestep_idx );
+void prepare_data_buffer_fine( cuDoubleComplex *data_buffer_fine, vcsbeam_context *vm,
+                    uintptr_t timestep_idx );
 void vmSendSToFits( vcsbeam_context *vm, mpi_psrfits *mpfs );
 
 float *create_pinned_data_buffer( size_t size );
@@ -1040,9 +1039,7 @@ vm_error vmReadNextSecond( vcsbeam_context *vm );
 cuDoubleComplex ****create_invJi( int nstation, int nchan, int pol );
 void              destroy_invJi( cuDoubleComplex ****array, int nstation, int nchan, int npol );
 
-cuDoubleComplex ****create_detected_beam( int npointing, int nsamples, int nchan, int npol );
-void              destroy_detected_beam( cuDoubleComplex ****array, int npointing,
-                                         int nsamples, int nchan );
+cuDoubleComplex *create_data_buffer_fine( int npointing, int nsamples, int nchan, int npol );
 
 void allocate_input_output_arrays( void **data, void **d_data, size_t size );
 void free_input_output_arrays( void *data, void *d_data );

--- a/include/vcsbeam.h.in
+++ b/include/vcsbeam.h.in
@@ -1027,7 +1027,8 @@ void vmPullE( vcsbeam_context *vm );
 void vmPullS( vcsbeam_context *vm );
 
 void prepare_detected_beam( cuDoubleComplex ****detected_beam,
-                   mpi_psrfits *mpfs, vcsbeam_context *vm );
+                   mpi_psrfits *mpfs, vcsbeam_context *vm,
+                   uintptr_t timestep_idx );
 void vmSendSToFits( vcsbeam_context *vm, mpi_psrfits *mpfs );
 
 float *create_pinned_data_buffer( size_t size );

--- a/include/vcsbeam.h.in
+++ b/include/vcsbeam.h.in
@@ -1116,7 +1116,7 @@ struct vdifinfo
     size_t samples_per_frame; // Number of time samples per vdif frame
     int dataarraylength;      // The frame length minus the header
     int bits;                 // Bits per sample
-    int nchan;                // Channels per framme
+    int nchan;                // Channels per frame
     int chan_width;           // Channel width in hertz
     int sample_rate;          // Sample rate in hertz
     int npol;                 // Number of polarisations
@@ -1142,7 +1142,9 @@ struct vdifinfo
 
     double BW;
 
-    long double MJD_epoch;
+    double MJD_start;
+    double sec_offset;
+    double MJD_epoch;
 
     char date_obs[24];
     char basefilename[1024];
@@ -1161,7 +1163,9 @@ void vdif_write_second( struct vdifinfo *vf, vdif_header *vhdr,
 
 void vmPopulateVDIFHeader(
         vcsbeam_context  *vm,
-        beam_geom        *beam_geom_vals );
+        beam_geom        *beam_geom_vals,
+        double           mjd_start,
+        double           sec_offset );
 
 void to_offset_binary( int8_t *i, int n );
 

--- a/include/vcsbeam.h.in
+++ b/include/vcsbeam.h.in
@@ -757,7 +757,7 @@ void vmFreePQIdxsHost( vcsbeam_context *vm );
 void vmFreePQIdxsDevice( vcsbeam_context *vm );
 
 
-void vmSetMaxGPUMem( vcsbeam_context *vm, uintptr_t max_gpu_mem_bytes );
+void vmSetMaxGPUMem( vcsbeam_context *vm, int nchunks );
 void vmPushChunk( vcsbeam_context *vm );
 void vmPushJ( vcsbeam_context *vm );
 
@@ -1118,6 +1118,7 @@ struct vdifinfo
     int nchan;                // Channels per framme
     int chan_width;           // Channel width in hertz
     int sample_rate;          // Sample rate in hertz
+    int npol;                 // Number of polarisations
     int iscomplex;            // Complex sample flag
     int threadid;             // Which thread are we
     char stationid[3];        // Which station are we

--- a/src/beam_vdif.c
+++ b/src/beam_vdif.c
@@ -121,11 +121,9 @@ void vdif_write_data( struct vdifinfo *vf, int8_t *output )
     ascii_header_set( ascii_header, "INSTRUMENT", "%s", "VDIF"          );
     ascii_header_set( ascii_header, "DATAFILE",   "%s", filename        );
 
-    ascii_header_set( ascii_header, "UTC_START",  "%s", vf->date_obs    );
     ascii_header_set( ascii_header, "MJD_START",  "%f", vf->MJD_start   );
-
-    ascii_header_set( ascii_header, "SEC_OFFSET", "%f", vf->sec_offset  );
     ascii_header_set( ascii_header, "MJD_EPOCH",  "%f", vf->MJD_epoch   );
+    ascii_header_set( ascii_header, "SEC_OFFSET", "%f", vf->sec_offset  );    
 
     ascii_header_set( ascii_header, "SOURCE",     "%s", vf->source      );
     ascii_header_set( ascii_header, "RA",         "%s", vf->ra_str      );

--- a/src/beam_vdif.c
+++ b/src/beam_vdif.c
@@ -121,6 +121,7 @@ void vdif_write_data( struct vdifinfo *vf, int8_t *output )
     ascii_header_set( ascii_header, "TELESCOPE",  "%s", vf->telescope );
     ascii_header_set( ascii_header, "MODE",       "%s", vf->obs_mode  );
     ascii_header_set( ascii_header, "FREQ",       "%f", vf->fctr      );
+    ascii_header_set( ascii_header, "NPOL",       "%d", vf->npol      );
 
     ascii_header_set( ascii_header, "BW",         "%f", vf->BW        );
     ascii_header_set( ascii_header, "RA",         "%s", vf->ra_str    );
@@ -217,6 +218,7 @@ void vmPopulateVDIFHeader(
 
         vm->vf[p].MJD_epoch = beam_geom_vals->intmjd + beam_geom_vals->fracmjd;
         vm->vf[p].fctr      = vm->obs_metadata->metafits_coarse_chans[coarse_chan_idx].chan_centre_hz / 1e6; // (MHz)
+        vm->vf[p].npol      = 2;
         strncpy( vm->vf[p].source, "unset", 24 );
 
         // The output file basename

--- a/src/beam_vdif.c
+++ b/src/beam_vdif.c
@@ -123,7 +123,7 @@ void vdif_write_data( struct vdifinfo *vf, int8_t *output )
 
     ascii_header_set( ascii_header, "MJD_START",  "%f", vf->MJD_start   );
     ascii_header_set( ascii_header, "MJD_EPOCH",  "%f", vf->MJD_epoch   );
-    ascii_header_set( ascii_header, "SEC_OFFSET", "%f", vf->sec_offset  );    
+    ascii_header_set( ascii_header, "SEC_OFFSET", "%f", vf->sec_offset  );
 
     ascii_header_set( ascii_header, "SOURCE",     "%s", vf->source      );
     ascii_header_set( ascii_header, "RA",         "%s", vf->ra_str      );

--- a/src/beam_vdif.c
+++ b/src/beam_vdif.c
@@ -115,18 +115,29 @@ void vdif_write_data( struct vdifinfo *vf, int8_t *output )
 
     // write a CPSR2 test header for DSPSR
     char ascii_header[MWA_HEADER_SIZE] = MWA_HEADER_INIT;
-    //ascii_header_set( ascii_header, "UTC_START", "%s", vf->date_obs  );
-    ascii_header_set( ascii_header, "DATAFILE",   "%s", filename      );
-    ascii_header_set( ascii_header, "INSTRUMENT", "%s", "VDIF"        );
-    ascii_header_set( ascii_header, "TELESCOPE",  "%s", vf->telescope );
-    ascii_header_set( ascii_header, "MODE",       "%s", vf->obs_mode  );
-    ascii_header_set( ascii_header, "FREQ",       "%f", vf->fctr      );
-    ascii_header_set( ascii_header, "NPOL",       "%d", vf->npol      );
+    
+    ascii_header_set( ascii_header, "TELESCOPE",  "%s", vf->telescope   );
+    ascii_header_set( ascii_header, "MODE",       "%s", vf->obs_mode    );
+    ascii_header_set( ascii_header, "INSTRUMENT", "%s", "VDIF"          );
+    ascii_header_set( ascii_header, "DATAFILE",   "%s", filename        );
 
-    ascii_header_set( ascii_header, "BW",         "%f", vf->BW        );
-    ascii_header_set( ascii_header, "RA",         "%s", vf->ra_str    );
-    ascii_header_set( ascii_header, "DEC",        "%s", vf->dec_str   );
-    ascii_header_set( ascii_header, "SOURCE",     "%s", vf->source    );
+    ascii_header_set( ascii_header, "UTC_START",  "%s", vf->date_obs    );
+    ascii_header_set( ascii_header, "MJD_START",  "%f", vf->MJD_start   );
+
+    ascii_header_set( ascii_header, "SEC_OFFSET", "%f", vf->sec_offset  );
+    ascii_header_set( ascii_header, "MJD_EPOCH",  "%f", vf->MJD_epoch   );
+
+    ascii_header_set( ascii_header, "SOURCE",     "%s", vf->source      );
+    ascii_header_set( ascii_header, "RA",         "%s", vf->ra_str      );
+    ascii_header_set( ascii_header, "DEC",        "%s", vf->dec_str     );
+
+    ascii_header_set( ascii_header, "FREQ",       "%f", vf->fctr        );
+    ascii_header_set( ascii_header, "BW",         "%f", vf->BW          );
+    ascii_header_set( ascii_header, "TSAMP",      "%f", 1e6/(float) vf->sample_rate );
+
+    ascii_header_set( ascii_header, "NBIT",       "%d", vf->bits        );
+    ascii_header_set( ascii_header, "NDIM",       "%d", vf->iscomplex+1 );
+    ascii_header_set( ascii_header, "NPOL",       "%d", vf->npol        );
 
     sprintf( filename, "%s.hdr", vf->basefilename );
     fs = fopen( filename,"w" );
@@ -140,10 +151,14 @@ void vdif_write_data( struct vdifinfo *vf, int8_t *output )
  *
  * @param vm The VCSBeam context struct
  * @param beam_geom_vals A `beam_geom` struct containing pointing information
+ * @param mjd_start The start MJD of the observation
+ * @param sec_offset The offset from the start of the observation in seconds
  */
 void vmPopulateVDIFHeader(
         vcsbeam_context  *vm,
-        beam_geom        *beam_geom_vals )
+        beam_geom        *beam_geom_vals,
+        double           mjd_start,
+        double           sec_offset )
 {
     // Write log message
     sprintf( vm->log_message, "Preparing headers for output (receiver channel %lu)",
@@ -216,9 +231,11 @@ void vmPopulateVDIFHeader(
 
         strncpy( vm->vf[p].date_obs, time_utc, sizeof(time_utc) );
 
-        vm->vf[p].MJD_epoch = beam_geom_vals->intmjd + beam_geom_vals->fracmjd;
-        vm->vf[p].fctr      = vm->obs_metadata->metafits_coarse_chans[coarse_chan_idx].chan_centre_hz / 1e6; // (MHz)
-        vm->vf[p].npol      = 2;
+        vm->vf[p].MJD_start  = mjd_start;
+        vm->vf[p].sec_offset = sec_offset;
+        vm->vf[p].MJD_epoch  = beam_geom_vals->intmjd + beam_geom_vals->fracmjd;
+        vm->vf[p].fctr       = vm->obs_metadata->metafits_coarse_chans[coarse_chan_idx].chan_centre_hz / 1e6; // (MHz)
+        vm->vf[p].npol       = 2;
         strncpy( vm->vf[p].source, "unset", 24 );
 
         // The output file basename

--- a/src/form_beam.cu
+++ b/src/form_beam.cu
@@ -652,12 +652,13 @@ void vmPullS( vcsbeam_context *vm )
  * @todo Remove prepare_detected_beam() and use a "host buffer" instead.
  */
 void prepare_detected_beam( cuDoubleComplex ****detected_beam,
-                   mpi_psrfits *mpfs, vcsbeam_context *vm )
+                   mpi_psrfits *mpfs, vcsbeam_context *vm,
+                   uintptr_t timestep_idx )
 {
     // Get shortcut variables
     uintptr_t nchan  = vm->nfine_chan;
     uintptr_t npol   = vm->obs_metadata->num_ant_pols; // = 2
-    int file_no = vm->chunk_to_load / vm->chunks_per_second;
+    int file_no = timestep_idx % 2;
 
     // Copy the data back from e back into the detected_beam array
     // Make sure we put it back into the correct half of the array, depending

--- a/src/metadata.c
+++ b/src/metadata.c
@@ -708,11 +708,11 @@ void vmMallocJVDevice( vcsbeam_context *vm )
     printf("%lu\n", vm->d_Jv_size_bytes);
     size_t mf, ma;
     cudaMemGetInfo(&mf, &ma);
-    printf("free: %lu ... total: %lu\n", mf, ma);
+    printf("free: %zu ... total: %zu\n", mf, ma);
     cudaMalloc( (void **)&vm->d_Jv_P,  vm->d_Jv_size_bytes );
     cudaCheckErrors( "vmMallocJVDevice: cudaMalloc(d_Jv_P) failed" );
     cudaMemGetInfo(&mf, &ma);
-    printf("free: %lu ... total: %lu\n", mf, ma);
+    printf("free: %zu ... total: %zu\n", mf, ma);
     cudaMalloc( (void **)&vm->d_Jv_Q,  vm->d_Jv_size_bytes );
     cudaCheckErrors( "vmMallocJVDevice: cudaMalloc(d_Jv_Q) failed" );
 }

--- a/src/mwa_header.h
+++ b/src/mwa_header.h
@@ -9,7 +9,7 @@
 #define __MWA_HEADER_h
 
 #define MWA_HEADER_SIZE 4096
-#define MWA_HEADER_VERSION 0.1
+#define MWA_HEADER_VERSION 0.2
 
 /* ************************************************************************
 
@@ -39,20 +39,34 @@
 */
 
 #define MWA_HEADER_INIT \
-"HDR_VERSION 0.1	# Version of this ASCII header\n" \
-"MWA_CAPTURE_VERSION 0.1	# Version of the Data Acquisition Software\n" \
-"MWA_SAMPLE_VERSION 0.1	# Version of the FFD FPGA Software\n" \
+"HDR_VERSION 0.2            # Version of this ASCII header\n" \
+"MWA_CAPTURE_VERSION 0.1    # Version of the Data Acquisition Software\n" \
+"MWA_SAMPLE_VERSION 0.1     # Version of the FFD FPGA Software\n" \
+"VCSBEAM_VERSION " VCSBEAM_VERSION "\n" \
 "\n" \
-"VCSTOOL_VERSION " VCSBEAM_VERSION "\n" \
+"TELESCOPE  MWA             # telescope name\n" \
+"MODE       unset           # observing mode\n" \
+"INSTRUMENT unset           # instrument name\n" \
+"DATAFILE   unset           # raw data file name\n" \
 "\n" \
-"TELESCOPE	mwa		# telescope name\n" \
+"UTC_START  unset           # yyyy-mm-dd-hh:mm:ss\n" \
+"MJD_START  unset           # MJD equivalent to the start UTC\n" \
 "\n" \
-"SOURCE		unset		# name of the astronomical source\n" \
-"RA		unset		# Right Ascension of the source\n" \
-"DEC		unset		# Declination of the source\n" \
+"SEC_OFFSET unset           # seconds offset from the start MJD/UTC\n" \
+"MJD_EPOCH  unset           # MJD of the data epoch\n" \
 "\n" \
-"FREQ		unset		# centre frequency on sky in MHz\n" \
-"BW		unset		# bandwidth of in MHz (-ve lower sb)\n" \
+"SOURCE     unset           # name of the astronomical source\n" \
+"RA         unset           # Right Ascension of the source\n" \
+"DEC        unset           # Declination of the source\n" \
+"\n" \
+"FREQ       unset           # centre frequency on sky in MHz\n" \
+"BW         unset           # bandwidth in MHz (-ve lower sb)\n" \
+"TSAMP      unset           # sampling interval in microseconds\n" \
+"\n" \
+"NBIT       unset           # number of bits per sample\n" \
+"NDIM       unset           # dimension of samples (2=complex, 1=real)\n" \
+"NPOL       unset           # number of polarisations observed\n" \
+
 /*
   
 

--- a/src/mwa_header.h
+++ b/src/mwa_header.h
@@ -49,11 +49,9 @@
 "INSTRUMENT unset           # instrument name\n" \
 "DATAFILE   unset           # raw data file name\n" \
 "\n" \
-"UTC_START  unset           # yyyy-mm-dd-hh:mm:ss\n" \
-"MJD_START  unset           # MJD equivalent to the start UTC\n" \
-"\n" \
-"SEC_OFFSET unset           # seconds offset from the start MJD/UTC\n" \
+"MJD_START  unset           # MJD of the start of the observation\n" \
 "MJD_EPOCH  unset           # MJD of the data epoch\n" \
+"SEC_OFFSET unset           # seconds offset from the start of the observation\n" \
 "\n" \
 "SOURCE     unset           # name of the astronomical source\n" \
 "RA         unset           # Right Ascension of the source\n" \
@@ -66,6 +64,7 @@
 "NBIT       unset           # number of bits per sample\n" \
 "NDIM       unset           # dimension of samples (2=complex, 1=real)\n" \
 "NPOL       unset           # number of polarisations observed\n" \
+"\n"
 
 /*
   

--- a/src/primary_beam.c
+++ b/src/primary_beam.c
@@ -151,13 +151,13 @@ void vmCalcB(
             {
                 // Use the 'dead' configuration temporarily
                 config_idx = DEAD_CONFIG;
-                errInt = calc_jones(pb->beam, az, za, pb->freq_hz, pb->delays[rf_input], pb->amps[rf_input],numAmps, zenith_norm, arrayLatitudeRad ,iauOrder , tempJones);
+                errInt = fee_calc_jones(pb->beam, az, za, pb->freq_hz, pb->delays[rf_input], pb->amps[rf_input],numAmps, zenith_norm, arrayLatitudeRad ,iauOrder , tempJones);
                 configs[config_idx]=(cuDoubleComplex *)(tempJones);
             }
             else if (configs[config_idx] == NULL) // Call Hyperbeam if this config hasn't been done yet
             {
                 // Get the calculated FEE Beam (using Hyperbeam)
-                errInt = calc_jones(pb->beam, az, za, pb->freq_hz, pb->delays[rf_input], pb->amps[rf_input],numAmps, zenith_norm, arrayLatitudeRad ,iauOrder , tempJones);
+                errInt = fee_calc_jones(pb->beam, az, za, pb->freq_hz, pb->delays[rf_input], pb->amps[rf_input],numAmps, zenith_norm, arrayLatitudeRad ,iauOrder , tempJones);
                 configs[config_idx]=(cuDoubleComplex *)(tempJones);
 
                 // Apply the parallactic angle correction
@@ -179,7 +179,7 @@ void vmCalcB(
 
             if (errInt !=0)
             {             
-                handle_hyperbeam_error("Primary Beam",183, "calc_jones");   
+                handle_hyperbeam_error("Primary Beam",183, "fee_calc_jones");   
                 exit(EXIT_FAILURE);
             }
 
@@ -494,11 +494,11 @@ void calc_normalised_beam_response( FEEBeam *beam, double az, double za, double 
 
     // Calculate the primary beam for this channel, in this direction
     int zenith_norm = 1;
-    errInt = calc_jones( beam, az, za, freq_hz, delays, amps,numAmps, zenith_norm, arrayLatitudeRad ,iauOrder , (double *)J );
+    errInt = fee_calc_jones( beam, az, za, freq_hz, delays, amps,numAmps, zenith_norm, arrayLatitudeRad ,iauOrder , (double *)J );
 
     if (errInt !=0)
     {
-        handle_hyperbeam_error("primary beam",504 ,"calc_jones");
+        handle_hyperbeam_error("primary beam",504 ,"fee_calc_jones");
         exit(EXIT_FAILURE);
     }
 

--- a/src/primary_beam.c
+++ b/src/primary_beam.c
@@ -151,13 +151,13 @@ void vmCalcB(
             {
                 // Use the 'dead' configuration temporarily
                 config_idx = DEAD_CONFIG;
-                errInt = fee_calc_jones(pb->beam, az, za, pb->freq_hz, pb->delays[rf_input], pb->amps[rf_input],numAmps, zenith_norm, arrayLatitudeRad ,iauOrder , tempJones);
+                errInt = calc_jones(pb->beam, az, za, pb->freq_hz, pb->delays[rf_input], pb->amps[rf_input],numAmps, zenith_norm, arrayLatitudeRad ,iauOrder , tempJones);
                 configs[config_idx]=(cuDoubleComplex *)(tempJones);
             }
             else if (configs[config_idx] == NULL) // Call Hyperbeam if this config hasn't been done yet
             {
                 // Get the calculated FEE Beam (using Hyperbeam)
-                errInt = fee_calc_jones(pb->beam, az, za, pb->freq_hz, pb->delays[rf_input], pb->amps[rf_input],numAmps, zenith_norm, arrayLatitudeRad ,iauOrder , tempJones);
+                errInt = calc_jones(pb->beam, az, za, pb->freq_hz, pb->delays[rf_input], pb->amps[rf_input],numAmps, zenith_norm, arrayLatitudeRad ,iauOrder , tempJones);
                 configs[config_idx]=(cuDoubleComplex *)(tempJones);
 
                 // Apply the parallactic angle correction
@@ -179,7 +179,7 @@ void vmCalcB(
 
             if (errInt !=0)
             {             
-                handle_hyperbeam_error("Primary Beam",183, "fee_calc_jones");   
+                handle_hyperbeam_error("Primary Beam",183, "calc_jones");   
                 exit(EXIT_FAILURE);
             }
 
@@ -494,11 +494,11 @@ void calc_normalised_beam_response( FEEBeam *beam, double az, double za, double 
 
     // Calculate the primary beam for this channel, in this direction
     int zenith_norm = 1;
-    errInt = fee_calc_jones( beam, az, za, freq_hz, delays, amps,numAmps, zenith_norm, arrayLatitudeRad ,iauOrder , (double *)J );
+    errInt = calc_jones( beam, az, za, freq_hz, delays, amps,numAmps, zenith_norm, arrayLatitudeRad ,iauOrder , (double *)J );
 
     if (errInt !=0)
     {
-        handle_hyperbeam_error("primary beam",504 ,"fee_calc_jones");
+        handle_hyperbeam_error("primary beam",504 ,"calc_jones");
         exit(EXIT_FAILURE);
     }
 


### PR DESCRIPTION
A few updates to the VDIF handing and writing. The code has been compiled and tested on Garrawarla, and the output has been tested using DSPSR and CDMT/prepfold. The bug fix does not appear to fix the issues with pulse broadening at short time scales (#45), but it does fix and issue I was having in CDMT where there were artefacts appearing every 1 second (after passing through the convolving filterbank).

Updates from @robotopia:

- [`7522697`](https://github.com/CIRA-Pulsars-and-Transients-Group/vcsbeam/commit/7522679b3df049dfca2bc8a1e41bf1f67f87d0c0): Adding back in the `-n` option to the beamformer to chunk the processing.
- [`f0433e7`](https://github.com/CIRA-Pulsars-and-Transients-Group/vcsbeam/commit/f0433e7fa80b2a978957a7cef8fa7816f62287be): Fixed bug where the first second of VDIF data was all zeros. This addresses #26.

Updates from @cplee1:

- [`99f8c2a`](https://github.com/CIRA-Pulsars-and-Transients-Group/vcsbeam/commit/99f8c2a1654f12b9b74aba938c9c700df52fcd20)/[`4242a19`](https://github.com/CIRA-Pulsars-and-Transients-Group/vcsbeam/commit/4242a1960e9479adbc7e28933f092e3a908e8f9a): Updated the ASCII header file which gets written for each VDIF file. Now includes NPOL (a new requirement in DSPSR) and some of the VDIF packet header info (for convenience/debugging and human readability). This addresses #47.
- [`ca32e97`](https://github.com/CIRA-Pulsars-and-Transients-Group/vcsbeam/commit/ca32e9728bdd5d299206bec8768de76f18b911af): Flattened the multi-dimensional array `detected_beam` containing the fine-channelised beamformed voltages, and renamed it to `data_buffer_fine` so that it's not confused with a buffer containing detected output.

__Example 1:__ Below is the beginning of the detected timeseries at a time resolution of 12.5 us, after dedispersing to zero DM. Instead of 1 full second of zeros, there is only ~1.5 ms of invalid data. This is where the PFB hits the edge of the data.

![Screenshot from 2024-05-21 13-35-32](https://github.com/CIRA-Pulsars-and-Transients-Group/vcsbeam/assets/96163140/5ade34f3-eb55-4cc5-930f-0d7d968d01a6)

__Example 2:__ Below is a coherently dedispersed detection of J0437-4715, from cdmt/prepfold and from dspsr/pdmp. The profile still looks smeared - even more smeared than the incoherently dedispersed profile in Bhat et al. 2018.

![ch16_cDM002 645_PSR_J0437-4715 pfd](https://github.com/CIRA-Pulsars-and-Transients-Group/vcsbeam/assets/96163140/f1326a1c-9b62-427b-8a13-561997bbaa23)

![J0437-4715_bins512_fchans16_tint8_pdmp](https://github.com/CIRA-Pulsars-and-Transients-Group/vcsbeam/assets/96163140/86a4a71d-dc1a-4c8f-a128-c98600902e1d)

__Example 3:__ The new ASCII header file format.

```
HDR_VERSION 0.2            # Version of this ASCII header
MWA_CAPTURE_VERSION 0.1    # Version of the Data Acquisition Software
MWA_SAMPLE_VERSION 0.1     # Version of the FFD FPGA Software
VCSBEAM_VERSION v4.2-22-gd9cb093

TELESCOPE    MWA                    # telescope name
MODE         PSR                    # observing mode
INSTRUMENT   VDIF                   # instrument name
DATAFILE     G0057_1253991112_04:37:15.90_-47:15:09.11_ch109.vdif   # raw data file name

UTC_START    2019-10-01T18:51:34    # yyyy-mm-dd-hh:mm:ss
MJD_START    58757.785810           # MJD equivalent to the start UTC

SEC_OFFSET   3000.000000            # seconds offset from the start MJD/UTC
MJD_EPOCH    58757.820532           # MJD of the data epoch

SOURCE       unset                  # name of the astronomical source
RA           04:37:15.90            # Right Ascension of the source
DEC          -47:15:09.11           # Declination of the source

FREQ         139.520000             # centre frequency on sky in MHz
BW           1.280000               # bandwidth in MHz (-ve lower sb)
TSAMP        0.781250               # sampling interval in microseconds

NBIT         8                      # number of bits per sample
NDIM         2                      # dimension of samples (2=complex, 1=real)
NPOL         2                      # number of polarisations observed
```