### PR TITLE
Fix for VDIF smearing issue

### DIFF
--- a/src/pfb.cpp
+++ b/src/pfb.cpp
@@ -900,8 +900,8 @@ __global__ void ipfb_kernel(
     }
 
     // out[] includes both polarisations, at adjacent indices
-    out[2*idx]   = out_real / K;
-    out[2*idx+1] = out_imag / K;
+    out[2*idx]   = -out_real / K;
+    out[2*idx+1] = -out_imag / K;
 
     __syncthreads();
 }
@@ -984,8 +984,11 @@ void cu_invert_pfb( gpuDoubleComplex *data_buffer_fine, int file_no,
                 }
                 else
                 {
-                    g->in_real[i] = gpuCreal( data_buffer_fine[j] );
-                    g->in_imag[i] = gpuCimag( data_buffer_fine[j] );
+                    // Here, the swapping of real <--> imag was made to fix the long-standing
+                    // "VDIF bug". It's unclear why we *have* to do this, but it seems to
+                    // work. There is probably some other swapping that happens secretly elsewhere.
+                    g->in_real[i] = gpuCimag( data_buffer_fine[j] );
+                    g->in_imag[i] = gpuCreal( data_buffer_fine[j] );
                 }
             }
         }


### PR DESCRIPTION
As the PR title suggests, these changes nominally fix the VDIF voltage smearing we have been plagued with for a long time. @robotopia notes that it specifically only changes the behaviour for VDIF output - there may still be a similar bug for the PSRFITS beam creation, but as that is a detected power output the real-imaginary component flip should at most result in the wrong signs for Q/U and/or V (which can be explored separately, as it is fixable after-the-fact in the meantime). 

@cplee1 Is exploring a few other examples, but so far a quick look at the J2241 seems to be MUCH better. 

Fixes #45 