### PR TITLE
Temporary bug-fix for NaN-filled output

### DIFF
--- a/build_hip.sh
+++ b/build_hip.sh
@@ -8,14 +8,14 @@ source "${BASH_UTILS_DIR}/build_utils.sh"
 
 # Set the program name and versions, used to create the installation paths.
 PROGRAM_NAME=vcsbeam
-PROGRAM_VERSION=devel
+PROGRAM_VERSION=patched
 # the following function sets up the installation path according to the
 # cluster the script is running on and the first argument given. The argument
 # can be:
 # - "group": install the software in the group wide directory
 # - "user": install the software only for the current user
 # - "test": install the software in the current working directory
-process_build_script_input group
+process_build_script_input user
 
 # load all the modules required for the program to compile and run.
 # the following command also adds those module names in the modulefile
@@ -23,7 +23,7 @@ process_build_script_input group
 
 # module use /software/projects/pawsey1045/setonix/2024.05/modules/zen3/gcc/12.2.0/
 # module_load module1/ver module2/ver ..
-module_load pal/0.9.8-yyskiux mwalib/1.3.3-qvtlpxn cfitsio/4.3.0 rocm/5.7.3 psrfits-utils/2023-10-08-ltewgrw vdifio/master-u6heigs hyperbeam/0.5.0-glmva5q
+module_load pal/0.9.8-yyskiux mwalib/1.5.0 cfitsio/4.3.0 rocm/5.7.3 psrfits-utils/2023-10-08-ennrbqc  vdifio/master-o4bnlck hyperbeam/0.9.3
 
 module load cmake/3.27.7
 

--- a/src/form_beam.cpp
+++ b/src/form_beam.cpp
@@ -298,7 +298,9 @@ __global__ void vmBeamform_kernel(int nfine_chan,
                 // Calculate beamform products for each antenna, and then add them together
                 // Calculate the coherent beam (B = J*phi*D)
                 gpuDoubleComplex ex_tmp = gpuCmul( phi[PHI_IDX(p,ant,c,nant,nc)], Jv_Q[Jv_IDX(p,s,c,ant,ns,nc,nant)] );
+                if(isnan(ex_tmp.x) || isnan(ex_tmp.y)) continue;
                 gpuDoubleComplex ey_tmp = gpuCmul( phi[PHI_IDX(p,ant,c,nant,nc)], Jv_P[Jv_IDX(p,s,c,ant,ns,nc,nant)] );
+                if(isnan(ey_tmp.x) || isnan(ey_tmp.y)) continue;
                 ex = gpuCadd(ex, ex_tmp);
                 ey = gpuCadd(ey, ey_tmp);
                 Nxx = gpuCadd(Nxx, gpuCmul( ex_tmp, gpuConj(ex_tmp)));


### PR DESCRIPTION
This is the minimum required change to ensure that output data are not corrupted. It is not as broad as #71 (which we need to investigate further), but nominally does the job for the moment. Upon the completion of a couple of tests, we'll merge this and make a new tag and release. 

The underlying cause of the NaNs and weird behaviour introduced when we initially tried to fix things will be explored in the near future, but for the sake of having a functioning beamformer we're happy to have this increment. 