### PR TITLE
Updates build script & enables unsafe atomics

### DIFF
--- a/build_hip.sh
+++ b/build_hip.sh
@@ -8,7 +8,7 @@ source "${BASH_UTILS_DIR}/build_utils.sh"
 
 # Set the program name and versions, used to create the installation paths.
 PROGRAM_NAME=vcsbeam
-PROGRAM_VERSION=patched
+PROGRAM_VERSION="atomics"
 # the following function sets up the installation path according to the
 # cluster the script is running on and the first argument given. The argument
 # can be:
@@ -21,24 +21,21 @@ process_build_script_input user
 # the following command also adds those module names in the modulefile
 # that this script will generate.
 
-# module use /software/projects/pawsey1045/setonix/2024.05/modules/zen3/gcc/12.2.0/
-# module_load module1/ver module2/ver ..
-module_load pal/0.9.8-yyskiux mwalib/1.5.0 cfitsio/4.3.0 rocm/5.7.3 psrfits-utils/2023-10-08-ennrbqc  vdifio/master-o4bnlck hyperbeam/0.9.3
+module_load hyperbeam/0.10.2-cpu mwalib/1.8.7 cfitsio/4.4.0 rocm/6.3.0 pal/0.9.8-gimtz45 psrfits-utils/2023-10-08-bawao2j vdifio/master-xv2az73
 
-module load cmake/3.27.7
+module load cmake/3.30.5
 
 mkdir build
 cd build
 cmake -DUSE_HIP=ON -DCMAKE_INSTALL_PREFIX=$INSTALL_DIR \
     -DCMAKE_CXX_COMPILER=hipcc \
-    -DCMAKE_CXX_FLAGS="--offload-arch=gfx90a -O3" \
+    -DCMAKE_CXX_FLAGS="--offload-arch=gfx90a -O3 -munsafe-fp-atomics" \
     -DHYPERBEAM_HDF5=/scratch/references/mwa/beam-models/mwa_full_embedded_element_pattern.h5 \
     -DCMAKE_C_COMPILER=hipcc \
+    -DCMAKE_C_FLAGS="-I${ROCM_PATH}/include" \
     -DCMAKE_BUILD_TYPE=Release \
     -DPSRFITS_UTILS_ROOT_DIR=${PAWSEY_PSRFITS_UTILS_HOME} -DPAL_ROOT_DIR=${PAWSEY_PAL_HOME} ..
 
 make VERBOSE=1 -j 12
 make install
 create_modulefile
-
-# NOTE: Needs to be built on the node with the GPU available (for HIP). 


### PR DESCRIPTION
The main change is the use of the `-munsafe-fp-atomics` compilation flag. A sad name, but it only means the compiler will use the hardware implementation of the atomic operations instead of a software one based on compare and swap.

I also updated the module versions of the dependencies.