### PR TITLE
Fix calibration indexing error

### DIFF
--- a/src/metadata.c
+++ b/src/metadata.c
@@ -190,7 +190,7 @@ void vmBindObsData(
     for (c = 0; c < num_coarse_chans_to_process; c++)
     {
         vm->coarse_chan_idxs_to_process[c] = c + first_coarse_chan_idx;
-        vm->cal_coarse_chan_idxs_to_process[c] = c;
+        vm->cal_coarse_chan_idxs_to_process[c] = c + first_coarse_chan_idx;
     }
 
     // Copy across the data directory


### PR DESCRIPTION
The tracking of the calibration channel and processing channel index was not aligned, thus solutions from only one coarse channel were being applied across the bandwidth. This, strangely, did not completely destroy the pulsar signals, but did result in a reduced S/N detection which was not noticed when the original change was made in PR#43 (committed on 1 Feb 2024). This fix resolves that and recovers the expected S/N as was demonstrated in older beamformer versions (e.g., v4.18). Unfortunately, it almost certainly break picket-fence processing. Further strengthens to need to have VCSBeam natively read in Hyperdrive solutions (where all the required metadata to match up channels is available) and deprecate the broken RTS and frustratingly complicated AO-style calibration interpretation.