### PR TITLE
Improves I/O performance by reading multiple seconds (files) into memory, in parallel

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,7 @@ project(vcsbeam)
 # TODO: Is there a way to make sure these are required and mutually exclusive?
 option(USE_CUDA "Compile the code with NVIDIA GPU support." OFF)
 option(USE_HIP "Compile the code with AMD GPU support." OFF)
+option(USE_OPENMP "Compile with OpenMP enabled." ON)
 
 # Find packages needed
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/Modules/")
@@ -85,6 +86,10 @@ add_library(vcsbeam STATIC
     ${vcsbeam_gpu_sources}
 )
 
+if(USE_OPENMP)
+    find_package(OpenMP REQUIRED)
+    target_link_libraries(vcsbeam OpenMP::OpenMP_CXX)
+endif()
 # Various gates defining which source files should be available based on
 # which dependencies were found on the system.
 if(MPI_FOUND AND PAL_FOUND AND PSRFITS_UTILS_FOUND)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,7 +88,7 @@ add_library(vcsbeam STATIC
 
 if(USE_OPENMP)
     find_package(OpenMP REQUIRED)
-    target_link_libraries(vcsbeam OpenMP::OpenMP_CXX)
+    target_link_libraries(vcsbeam OpenMP::OpenMP_C OpenMP::OpenMP_CXX)
 endif()
 # Various gates defining which source files should be available based on
 # which dependencies were found on the system.

--- a/app/fine_pfb_offline.c
+++ b/app/fine_pfb_offline.c
@@ -22,6 +22,7 @@ struct fine_pfb_offline_opts {
     char              *coarse_chan_str;  // Absolute or relative coarse channel number
     char              *analysis_filter;  // Which analysis filter to use
     int                nchunks;          // Split each second into this many processing chunks
+    int                seconds_buffer_size; // Number of seconds to preload into memory to increase I/O bandwidth usage.
 };
 
 /***********************
@@ -43,7 +44,7 @@ int main( int argc, char *argv[] )
 
     // Set up the VCS metadata struct
     bool use_mpi = false;
-    vcsbeam_context *vm = vmInit( use_mpi );
+    vcsbeam_context *vm = vmInit( use_mpi, opts.seconds_buffer_size );
 
     vmLoadObsMetafits( vm, opts.metafits );
     vmBindObsData( vm,
@@ -121,6 +122,7 @@ void usage()
             "\t                           File [RUNTIME_DIR]/FILTER.dat must exist [default: FINEPFB]\n"
             "\t-T, --nseconds=VAL         Process VAL seconds of data [default: as many as possible]\n"
             "\t-n, --nchunks=VAL          Split each second's worth of data into VAL processing chunks\n"
+            "\t-Z, --seconds-buffer=N    Preload N seconds into memory to improve I/O performance.\n"
             "\t                           [default: 1]\n"
           );
 
@@ -140,6 +142,7 @@ void fine_pfb_offline_parse_cmdline( int argc, char **argv, struct fine_pfb_offl
     opts->coarse_chan_str    = NULL;  // Absolute or relative coarse channel
     opts->analysis_filter    = NULL;
     opts->nchunks            = 1;
+    opts->seconds_buffer_size = 0;
 
     if (argc > 1) {
 
@@ -155,18 +158,22 @@ void fine_pfb_offline_parse_cmdline( int argc, char **argv, struct fine_pfb_offl
                 {"metafits",        required_argument, 0, 'm'},
                 {"nchunks",         required_argument, 0, 'n'},
                 {"nseconds",        required_argument, 0, 'T'},
-                {"version",         required_argument, 0, 'V'}
+                {"version",         required_argument, 0, 'V'},
+                {"seconds-buffer",  required_argument, 0, 'Z'}
             };
 
             int option_index = 0;
             c = getopt_long( argc, argv,
-                             "A:b:d:f:hm:n:T:V",
+                             "A:b:d:f:hm:n:T:VZ:",
                              long_options, &option_index);
             if (c == -1)
                 break;
 
             switch(c)
             {
+                case 'Z':
+                    opts->seconds_buffer_size = atoi(optarg);
+                    break;
                 case 'A':
                     opts->analysis_filter = (char *)malloc( strlen(optarg) + 1 );
                     strcpy( opts->analysis_filter, optarg );

--- a/app/make_mwa_incoh_beam.c
+++ b/app/make_mwa_incoh_beam.c
@@ -33,6 +33,7 @@ struct cmd_line_opts {
     char              *coarse_chan_str;   // Absolute or relative coarse channel number
     char              *outfile;       // Base name of the output PSRFITS file
     int                max_sec_per_file;    // Number of seconds per fits file
+    int                seconds_buffer_size; // Number of seconds to preload into memory to increase I/O bandwidth usage.
 };
 
 /*************************************
@@ -57,7 +58,7 @@ int main(int argc, char **argv)
     make_incoh_beam_parse_cmdline( argc, argv, &opts );
 
     bool use_mpi = true;
-    vcsbeam_context *vm = vmInit( use_mpi );
+    vcsbeam_context *vm = vmInit( use_mpi, opts.seconds_buffer_size);
     vmLoadObsMetafits( vm, opts.metafits );
     vmBindObsData( vm,
         opts.coarse_chan_str, 1, vm->coarse_chan_idx,
@@ -213,6 +214,7 @@ void usage()
             "\t                          [default: \"<PROJECT>_<OBSID>_incoh_ch<CHAN>\"]\n"
             "\t-S, --max_output_t=SECS   Maximum number of SECS per output FITS file [default: 200]\n"
             "\t-T, --nseconds=VAL        Process VAL seconds of data [default: as many as possible]\n"
+            "\t-Z, --seconds-buffer=N    Preload N seconds into memory to improve I/O performance.\n"
            );
 
     printf( "\nOTHER OPTIONS\n\n"
@@ -234,6 +236,7 @@ void make_incoh_beam_parse_cmdline(
     opts->outfile          = NULL; // Base name of the output PSRFITS file
     opts->coarse_chan_str  = NULL; // Absolute or relative coarse channel
     opts->max_sec_per_file = 200;  // Number of seconds per fits files
+    opts->seconds_buffer_size = 0;
 
     if (argc > 1)
     {
@@ -249,18 +252,21 @@ void make_incoh_beam_parse_cmdline(
                 {"outfile",         required_argument, 0, 'o'},
                 {"max_output_t",    required_argument, 0, 'S'},
                 {"nseconds",        required_argument, 0, 'T'},
-                {"version",         no_argument,       0, 'V'}
+                {"version",         no_argument,       0, 'V'},
+                {"seconds-buffer",  required_argument, 0, 'Z'}
             };
 
             int option_index = 0;
             c = getopt_long( argc, argv,
-                             "b:d:f:hm:o:S:T:V",
+                             "b:d:f:hm:o:S:T:VZ:",
                              long_options, &option_index);
             if (c == -1)
                 break;
 
             switch(c) {
-
+                case 'Z':
+                    opts->seconds_buffer_size = atoi(optarg);
+                    break;
                 case 'b':
                     opts->begin_str = strdup(optarg);
                     break;

--- a/app/make_mwa_tied_array_beam.c
+++ b/app/make_mwa_tied_array_beam.c
@@ -457,7 +457,7 @@ void usage()
             "\t                           to convert the antenna numbers listed in the RTS 'flagged_tiles.txt' file into human-\n"
             "\t                           readable tile names.\n"
             "\t-k, --picket-fence         Input data is picket fenced data. Will assume the calibration solution contains the\n"
-            "\t                           same set of channels as the input data."
+            "\t                           same set of channels as the input data.\n"
             "\t-O, --offringa             The calibration solution is in the Offringa format instead of\n"
             "\t                           the default RTS format. In this case, the argument to -C should\n" 
             "\t                           be the full path to the binary solution file.\n"

--- a/app/make_mwa_tied_array_beam.c
+++ b/app/make_mwa_tied_array_beam.c
@@ -57,6 +57,7 @@ struct make_tied_array_beam_opts {
     bool               smart;            // Use legacy settings for PFB
     int                max_sec_per_file; // Number of seconds per fits files
     int                nchunks;          // Split each second into this many processing chunks
+    int                seconds_buffer_size; // Number of seconds to be pre-loaded and stored into memory, to improve I/O performance.
 };
 
 /***********************
@@ -83,7 +84,7 @@ int main(int argc, char **argv)
 
     // Create an mwalib metafits context and associated metadata
     bool use_mpi = true;
-    vcsbeam_context *vm = vmInit( use_mpi );
+    vcsbeam_context *vm = vmInit( use_mpi, opts.seconds_buffer_size);
 
     vmPrintTitle( vm, "Beamformer" );
 
@@ -465,6 +466,7 @@ void usage()
             "\t                                exp(PH*F + OFFS)\n"
             "\t                           Setting PH = OFFS = 0 is equivalent to not performing any phase correction\n"
             "\t-X, --cross-terms          Retain the PQ and QP terms of the calibration solution [default: off]\n"
+            "\t-Z, --seconds-buffer=N    Preload N seconds into memory to improve I/O performance.\n"
           );
 
     printf( "\nMEMORY OPTIONS\n\n"
@@ -510,6 +512,7 @@ void make_tied_array_beam_parse_cmdline(
     opts->phase_slope          = 0.0;
     opts->custom_pq_correction = false;
     opts->use_bandpass         = false; // use the Bandpass calibration solutions
+    opts->seconds_buffer_size  = 0; // Number of seconds to be preloaded and stored in memory. Default: 0, no buffering.
 
     if (argc > 1) {
 
@@ -541,12 +544,13 @@ void make_tied_array_beam_parse_cmdline(
                 {"nchunks",         required_argument, 0, 'n'},
                 {"smart",           no_argument,       0, 's'},
                 {"help",            required_argument, 0, 'h'},
-                {"version",         required_argument, 0, 'V'}
+                {"version",         required_argument, 0, 'V'},
+                {"seconds-buffer",  required_argument, 0, 'Z'}
             };
 
             int option_index = 0;
             c = getopt_long( argc, argv,
-                             "A:b:Bc:C:d:D:e:f:F:hm:n:N:OpP:R:sS:t:T:U:vVX",
+                             "A:b:Bc:C:d:D:e:f:F:hm:n:N:OpP:R:sS:t:T:U:vVXZ:",
                              long_options, &option_index);
             if (c == -1)
                 break;
@@ -611,6 +615,9 @@ void make_tied_array_beam_parse_cmdline(
                                 "-%c argument must be either 1 or 4\n", c );
                         exit(EXIT_FAILURE);
                     }
+                    break;
+                case 'Z':
+                    opts->seconds_buffer_size = atoi(optarg);
                     break;
                 case 'O':
                     opts->cal_type = CAL_OFFRINGA;

--- a/build_hip.sh
+++ b/build_hip.sh
@@ -8,7 +8,7 @@ source "${BASH_UTILS_DIR}/build_utils.sh"
 
 # Set the program name and versions, used to create the installation paths.
 PROGRAM_NAME=vcsbeam
-PROGRAM_VERSION="atomics"
+PROGRAM_VERSION="buffer"
 # the following function sets up the installation path according to the
 # cluster the script is running on and the first argument given. The argument
 # can be:
@@ -27,15 +27,15 @@ module load cmake/3.30.5
 
 mkdir build
 cd build
-cmake -DUSE_HIP=ON -DCMAKE_INSTALL_PREFIX=$INSTALL_DIR \
+cmake -DUSE_OPENMP=ON -DUSE_HIP=ON -DCMAKE_INSTALL_PREFIX=$INSTALL_DIR \
     -DCMAKE_CXX_COMPILER=hipcc \
     -DCMAKE_CXX_FLAGS="--offload-arch=gfx90a -O3 -munsafe-fp-atomics" \
     -DHYPERBEAM_HDF5=/scratch/references/mwa/beam-models/mwa_full_embedded_element_pattern.h5 \
     -DCMAKE_C_COMPILER=hipcc \
     -DCMAKE_C_FLAGS="-I${ROCM_PATH}/include" \
-    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_BUILD_TYPE=RelWithDebugInfo \
     -DPSRFITS_UTILS_ROOT_DIR=${PAWSEY_PSRFITS_UTILS_HOME} -DPAL_ROOT_DIR=${PAWSEY_PAL_HOME} ..
 
 make VERBOSE=1 -j 12
 make install
-create_modulefile
+# create_modulefile

--- a/include/vcsbeam.h.in
+++ b/include/vcsbeam.h.in
@@ -666,8 +666,23 @@ typedef struct vcsbeam_context_t
         Furthermore, multiple files, corresponding to multiple seconds, can be read in parallel and cached.
         This extra functionality requires minimal change to `vmReadNextSecond` transparent to the rest
         of the VCSBeam code.
-    
     */
+    bool use_seconds_buffer;
+    struct {
+        // where the data is stored.
+        char *data;
+        // next timestep file to read.
+        uint64_t current_timestep_idx;
+        // keeps track of the number of remaining seconds that need to be processed.
+        uint64_t n_remaining_seconds;
+        // number of seconds in the buffer that have been already processed.
+        uint64_t count;
+        // number of seconds currently stored in the buffer.
+        uint64_t size;
+        // how many seconds the buffer can store.
+        uint64_t capacity;
+    } seconds_buffer;
+
 } vcsbeam_context;
 
 #define NO_ANTENNA_FOUND  -1
@@ -678,7 +693,7 @@ extern "C" {
 
 void vmCheckError( vm_error err );
 
-vcsbeam_context *vmInit( bool use_mpi );
+vcsbeam_context *vmInit( bool use_mpi, int seconds_buffer_size );
 
 /**    
  * vmBindObsData

--- a/include/vcsbeam.h.in
+++ b/include/vcsbeam.h.in
@@ -657,6 +657,17 @@ typedef struct vcsbeam_context_t
     char log_message[MAX_COMMAND_LENGTH];
 
     char error_message[ERROR_MESSAGE_LEN]; // MWALIB error message buffer
+
+    /**
+        2025 Pawsey Uptake Project - Cristian.
+        This patch adds the option to read an entire input file at once, as opposed to only read one second 
+        at a time. The change drastically improves I/O bandwidth especially when reading .sub files. The
+        file is cached into a dedicated buffer from which the `vmReadNextSecond` function will read from.
+        Furthermore, multiple files, corresponding to multiple seconds, can be read in parallel and cached.
+        This extra functionality requires minimal change to `vmReadNextSecond` transparent to the rest
+        of the VCSBeam code.
+    
+    */
 } vcsbeam_context;
 
 #define NO_ANTENNA_FOUND  -1

--- a/include/vcsbeam.h.in
+++ b/include/vcsbeam.h.in
@@ -523,6 +523,30 @@ typedef struct forward_pfb_t
 } forward_pfb;
 
 
+/**
+    2025 Pawsey Uptake Project - Cristian.
+    This patch adds the option to read an entire input file at once, as opposed to only read one second
+    at a time. The change drastically improves I/O bandwidth especially when reading .sub files. The
+    file is cached into a dedicated buffer from which the `vmReadNextSecond` function will read from.
+    Furthermore, multiple files, corresponding to multiple seconds, can be read in parallel and cached.
+    This extra functionality requires minimal change to `vmReadNextSecond` transparent to the rest
+    of the VCSBeam code.
+*/
+struct seconds_buffer_t {
+    // where the data is stored.
+    char *data;
+    // next timestep file to read.
+    uint64_t current_timestep_idx;
+    // keeps track of the number of remaining seconds that need to be processed.
+    uint64_t n_remaining_seconds;
+    // number of seconds in the buffer that have been already processed.
+    uint64_t count;
+    // number of seconds currently stored in the buffer.
+    uint64_t size;
+    // how many seconds the buffer can store.
+    uint64_t capacity;
+};
+
 typedef struct vcsbeam_context_t
 {
     // MPI
@@ -659,30 +683,8 @@ typedef struct vcsbeam_context_t
 
     char error_message[ERROR_MESSAGE_LEN]; // MWALIB error message buffer
 
-    /**
-        2025 Pawsey Uptake Project - Cristian.
-        This patch adds the option to read an entire input file at once, as opposed to only read one second 
-        at a time. The change drastically improves I/O bandwidth especially when reading .sub files. The
-        file is cached into a dedicated buffer from which the `vmReadNextSecond` function will read from.
-        Furthermore, multiple files, corresponding to multiple seconds, can be read in parallel and cached.
-        This extra functionality requires minimal change to `vmReadNextSecond` transparent to the rest
-        of the VCSBeam code.
-    */
+    struct seconds_buffer_t seconds_buffer;
     bool use_seconds_buffer;
-    struct {
-        // where the data is stored.
-        char *data;
-        // next timestep file to read.
-        uint64_t current_timestep_idx;
-        // keeps track of the number of remaining seconds that need to be processed.
-        uint64_t n_remaining_seconds;
-        // number of seconds in the buffer that have been already processed.
-        uint64_t count;
-        // number of seconds currently stored in the buffer.
-        uint64_t size;
-        // how many seconds the buffer can store.
-        uint64_t capacity;
-    } seconds_buffer;
 
 } vcsbeam_context;
 

--- a/src/metadata.c
+++ b/src/metadata.c
@@ -960,7 +960,7 @@ void read_from_buffer(vcsbeam_context *vm,
         // in each file.
         // TODO: check gps_second_count is less than buffer size
         // TODO: find a clever way of doing this.
-        size_t desired_seconds_in_buffer = 32;
+        size_t desired_seconds_in_buffer = 64;
         // this will ensure each file is read in full
         size_t total_seconds = vm->seconds_per_file * (desired_seconds_in_buffer / vm->seconds_per_file);
         size_t total_bytes = vm->bytes_per_second * total_seconds;

--- a/src/metadata.c
+++ b/src/metadata.c
@@ -984,34 +984,36 @@ void read_next_second_from_buffer(vcsbeam_context *vm,
                     const char *error_message,
                     size_t error_message_length){
     
-    if(vm->seconds_buffer.data == NULL){
+    struct seconds_buffer_t* vmsb = &(vm->seconds_buffer);
+    
+    if(vmsb->data == NULL){
         // First time the structure is accessed. It must be initialised.
         // Initially, all seconds must still be processed.
-        vm->seconds_buffer.n_remaining_seconds = vm->nfiletimes * vm->seconds_per_file;
-        size_t desired_seconds_in_buffer = vm->seconds_buffer.capacity;
+        vmsb->n_remaining_seconds = vm->nfiletimes * vm->seconds_per_file;
+        size_t desired_seconds_in_buffer = vmsb->capacity;
         // this will ensure each file is read in full
-        vm->seconds_buffer.capacity = vm->seconds_per_file * (desired_seconds_in_buffer / vm->seconds_per_file);
-        size_t total_bytes = vm->bytes_per_second * vm->seconds_buffer.capacity;
+        vmsb->capacity = vm->seconds_per_file * (desired_seconds_in_buffer / vm->seconds_per_file);
+        size_t total_bytes = vm->bytes_per_second * vmsb->capacity;
        
         sprintf(vm->log_message, "read_next_second_from_buffer: will allocate %.4f GiB for 'seconds_buffer', "
-            "corresponding to %lu seconds.", (total_bytes / (1024.0f * 1024.0f * 1024.0f)), vm->seconds_buffer.capacity);
+            "corresponding to %lu seconds.", (total_bytes / (1024.0f * 1024.0f * 1024.0f)), vmsb->capacity);
         logger_message(vm->log, vm->log_message);
         
-        vm->seconds_buffer.data = (char*) malloc(total_bytes);
-        if(!(vm->seconds_buffer.data)){
+        vmsb->data = (char*) malloc(total_bytes);
+        if(!(vmsb->data)){
             fprintf(stderr, "Error allocating memory for 'seconds_buffer'.\n");
             exit(1);
         }
-        vm->seconds_buffer.current_timestep_idx = vm->vcs_metadata->common_timestep_indices[0];
+        vmsb->current_timestep_idx = vm->vcs_metadata->common_timestep_indices[0];
     }
 
-    if(vm->seconds_buffer.count == vm->seconds_buffer.size){
+    if(vmsb->count == vmsb->size){
         // All seconds in the buffer have been used. The buffer is empty, refill it
-        size_t seconds_to_read = vm->seconds_buffer.capacity < vm->seconds_buffer.n_remaining_seconds ? \
-            vm->seconds_buffer.capacity : vm->seconds_buffer.n_remaining_seconds;
-        size_t start_timestep_idx = vm->seconds_buffer.current_timestep_idx;
+        size_t seconds_to_read = vmsb->capacity < vmsb->n_remaining_seconds ? \
+            vmsb->capacity : vmsb->n_remaining_seconds;
+        size_t start_timestep_idx = vmsb->current_timestep_idx;
         size_t n_timesteps_to_read = seconds_to_read / vm->seconds_per_file;
-        size_t end_timestep_idx = vm->seconds_buffer.current_timestep_idx + n_timesteps_to_read;
+        size_t end_timestep_idx = vmsb->current_timestep_idx + n_timesteps_to_read;
         size_t read_size = ((size_t) vm->bytes_per_second) * vm->seconds_per_file;
         sprintf(vm->log_message, "read_next_second_from_buffer: will now read %lu seconds into the buffer.\n", seconds_to_read);
         logger_message(vm->log, vm->log_message);
@@ -1021,22 +1023,22 @@ void read_next_second_from_buffer(vcsbeam_context *vm,
             if(mwalib_voltage_context_read_file(vm->vcs_context,
                                          timestep_idx,
                                          voltage_coarse_chan_index,
-                                         vm->seconds_buffer.data + read_size * (timestep_idx - start_timestep_idx), read_size,
+                                         vmsb->data + read_size * (timestep_idx - start_timestep_idx), read_size,
                                          vm->error_message, ERROR_MESSAGE_LEN)!= MWALIB_SUCCESS){
                  fprintf( stderr, "error: mwalib_voltage_context_read_file failed: %s", vm->error_message );
                  exit(EXIT_FAILURE);
             }
         }
-        vm->seconds_buffer.count = 0u;
-        vm->seconds_buffer.size = seconds_to_read;
-        vm->seconds_buffer.n_remaining_seconds -= seconds_to_read;
-        vm->seconds_buffer.current_timestep_idx += n_timesteps_to_read;
+        vmsb->count = 0u;
+        vmsb->size = seconds_to_read;
+        vmsb->n_remaining_seconds -= seconds_to_read;
+        vmsb->current_timestep_idx += n_timesteps_to_read;
     }
 
-    char *source = vm->seconds_buffer.data + vm->seconds_buffer.count * vm->bytes_per_second;
+    char *source = vmsb->data + vmsb->count * vm->bytes_per_second;
     // read the next seocond into the actual VCSBeam buffer.
     memcpy(buffer_ptr, source, vm->bytes_per_second);
-    vm->seconds_buffer.count += 1;
+    vmsb->count += 1;
 }
 
 

--- a/src/metadata.c
+++ b/src/metadata.c
@@ -942,19 +942,26 @@ void vmPushChunk( vcsbeam_context *vm )
 
 
 /**
-    @Cristian: here is a simple test to see if we can read as much data as we can in one go.
-    And whether that will improve the I/O performance of the program. At first, it is all
-    sequential. That is, a buffer is allocated, and populated when emptied, and consumed by
-    vmReadNextSecond transparently.
+    2025 Uptake Project with Pawsey. Author: Cristian Di Pietrantonio.
+
+    The `read_next_second_from_buffer` function implements an alternative to
+    the mwalib's `mwalib_voltage_context_read_second` function. The difference
+    between the two is that this function, `read_next_second_from_buffer`,
+    will read entire input voltage files, possibly in parallel, and cache the
+    contents in an in-memory buffer. The function will return the next second
+    of data to be processed, read from said buffer instead of the input file
+    directly. In other words, the function adds a caching mechanism to improve
+    the I/O bandwidth my reading larger chunks of data, in parallel.
+    The `seconds_buffer` structure is defined in `vcsbeam.h.in`, lines 660-686.
+
+    The function is called in `vmReadNextSecond` when the option
+    `vm->use_seconds_buffer` is set to true. Otherwise, mwalib is called
+    directly.
 
     We are making the assumption that seconds are processed contiguously. That is,
     the sequence of GPS seconds that is passed to vmReadNextSeconds corresponds to the
     sequence defined by the files referenced in `common_timestep_indices`.
 */
-
-
-
-
 void read_next_second_from_buffer(vcsbeam_context *vm,
                     size_t voltage_coarse_chan_index,
                     signed char *buffer_ptr,
@@ -973,7 +980,7 @@ void read_next_second_from_buffer(vcsbeam_context *vm,
        
         sprintf(vm->log_message, "read_next_second_from_buffer: will allocate %.4f GiB for 'seconds_buffer', "
             "corresponding to %lu seconds.", (total_bytes / (1024.0f * 1024.0f * 1024.0f)), vm->seconds_buffer.capacity);
-        logger_message( vm->log, vm->log_message );
+        logger_message(vm->log, vm->log_message);
         
         vm->seconds_buffer.data = (char*) malloc(total_bytes);
         if(!(vm->seconds_buffer.data)){
@@ -991,9 +998,8 @@ void read_next_second_from_buffer(vcsbeam_context *vm,
         size_t n_timesteps_to_read = seconds_to_read / vm->seconds_per_file;
         size_t end_timestep_idx = vm->seconds_buffer.current_timestep_idx + n_timesteps_to_read;
         size_t read_size = ((size_t) vm->bytes_per_second) * vm->seconds_per_file;
-        logger_start_stopwatch( vm->log, "read-seconds", true);
-        // sprintf(vm->log_message, "read_next_second_from_buffer: will now read %lu seconds into the buffer.\n", seconds_to_read);
-        logger_message( vm->log, vm->log_message );
+        sprintf(vm->log_message, "read_next_second_from_buffer: will now read %lu seconds into the buffer.\n", seconds_to_read);
+        logger_message(vm->log, vm->log_message);
         // Read multiple (file) timesteps in parallel using OpenMP
         #pragma omp parallel for schedule(static)
         for(size_t timestep_idx = start_timestep_idx; timestep_idx < end_timestep_idx; timestep_idx += 1){
@@ -1010,7 +1016,6 @@ void read_next_second_from_buffer(vcsbeam_context *vm,
         vm->seconds_buffer.size = seconds_to_read;
         vm->seconds_buffer.n_remaining_seconds -= seconds_to_read;
         vm->seconds_buffer.current_timestep_idx += n_timesteps_to_read;
-        logger_stop_stopwatch( vm->log, "read-seconds");
     }
 
     char *source = vm->seconds_buffer.data + vm->seconds_buffer.count * vm->bytes_per_second;

--- a/src/metadata.c
+++ b/src/metadata.c
@@ -1015,7 +1015,7 @@ void read_next_second_from_buffer(vcsbeam_context *vm,
         size_t n_timesteps_to_read = seconds_to_read / vm->seconds_per_file;
         size_t end_timestep_idx = vmsb->current_timestep_idx + n_timesteps_to_read;
         size_t read_size = ((size_t) vm->bytes_per_second) * vm->seconds_per_file;
-        sprintf(vm->log_message, "read_next_second_from_buffer: will now read %lu seconds into the buffer.\n", seconds_to_read);
+        sprintf(vm->log_message, "read_next_second_from_buffer: will now read %zu seconds into the buffer.\n", seconds_to_read);
         logger_message(vm->log, vm->log_message);
         // Read multiple (file) timesteps in parallel using OpenMP
         #pragma omp parallel for schedule(static)

--- a/src/metadata.c
+++ b/src/metadata.c
@@ -27,7 +27,7 @@
  * Once the VCSBeam context is finished with, it should be freed with a call
  * to destroy_vcsbeam_context().
  */
-vcsbeam_context *vmInit( bool use_mpi )
+vcsbeam_context *vmInit( bool use_mpi, int seconds_buffer_size )
 {
     // Allocate memory for the VCSBEAM_METADATA struct
     vcsbeam_context *vm = (vcsbeam_context *)malloc( sizeof(vcsbeam_context) );
@@ -46,7 +46,19 @@ vcsbeam_context *vmInit( bool use_mpi )
         vm->mpi_rank = PERFORMANCE_NO_MPI;
     }
     vm->writer = 0;
-
+    if(seconds_buffer_size > 0){
+        vm->use_seconds_buffer = true;
+        // To keep the implementation simple and contained to a single function,
+        // the actual initialisation of the structure happens the first time it
+        // is accessed.
+        vm->seconds_buffer.data = NULL;
+        vm->seconds_buffer.current_timestep_idx = 0u;
+        vm->seconds_buffer.n_remaining_seconds = 0u;
+        vm->seconds_buffer.count = 0u;
+        vm->seconds_buffer.size = 0u;
+        // just a way to pass the buffer size to the initialisation function
+        vm->seconds_buffer.capacity = (unsigned int) seconds_buffer_size;
+    }
     // TODO: Change this to give user flexibility of how to use mpi structure
     vm->ncoarse_chans   = vm->mpi_size;
     vm->coarse_chan_idx = (vm->use_mpi ? vm->mpi_rank : 0);
@@ -141,6 +153,9 @@ vcsbeam_context *vmInit( bool use_mpi )
     logger_add_stopwatch( vm->log, "download",  "Downloading the data to the host" );
     logger_add_stopwatch( vm->log, "splice",    "Splicing coarse channels together" );
     logger_add_stopwatch( vm->log, "write",     "Writing out data to file" );
+    logger_add_stopwatch( vm->log, "init-buffer",     "Initialise the memory buffer." );
+    logger_add_stopwatch( vm->log, "read-seconds",     "Reading seconds into memory buffer." );
+    
 
     // Initialise pointing RAs and Decs to NULL
     vm->ras_hours = NULL;
@@ -938,95 +953,71 @@ void vmPushChunk( vcsbeam_context *vm )
     sequence defined by the files referenced in `common_timestep_indices`.
 */
 
-struct {
-    // where the data is stored.
-    char *data;
-    // next timestep file to read.
-    uint64_t current_timestep_idx;
-    // keeps track of the number of remaining seconds that need to be processed.
-    uint64_t n_remaining_seconds;
-    // number of seconds in the buffer that have been already processed.
-    uint64_t count;
-    // number of seconds currently stored in the buffer.
-    uint64_t size;
-    // how many seconds can the buffer store.
-    uint64_t capacity;
-} seconds_buffer = {NULL, 0u, 0u, 0u, 0u, 0u};
 
 
-void read_second_from_buffer(vcsbeam_context *vm,
+
+void read_next_second_from_buffer(vcsbeam_context *vm,
                     size_t voltage_coarse_chan_index,
                     signed char *buffer_ptr,
                     size_t buffer_len,
                     const char *error_message,
                     size_t error_message_length){
     
-    if(seconds_buffer.data == NULL){
-        // Initialise the structure
+    if(vm->seconds_buffer.data == NULL){
+        // First time the structure is accessed. It must be initialised.
         // Initially, all seconds must still be processed.
-        seconds_buffer.n_remaining_seconds = vm->nfiletimes * vm->seconds_per_file;
-        printf("CDP DEBUG: n_remaining_seconds is set to: %lu, "
-            "with nfiletimes = %lu and seconds per file = %lu\n",
-            seconds_buffer.n_remaining_seconds, vm->nfiletimes, vm->seconds_per_file);
-        // the following must be greater than the number of seconds
-        // in each file.
-        // TODO: check gps_second_count is less than buffer size
-        // TODO: find a clever way of doing this.
-        size_t desired_seconds_in_buffer = 64;
+        vm->seconds_buffer.n_remaining_seconds = vm->nfiletimes * vm->seconds_per_file;
+        size_t desired_seconds_in_buffer = vm->seconds_buffer.capacity;
         // this will ensure each file is read in full
-        seconds_buffer.capacity = vm->seconds_per_file * (desired_seconds_in_buffer / vm->seconds_per_file);
-        size_t total_bytes = vm->bytes_per_second * seconds_buffer.capacity;
-        printf("Will allocate %.4f GiB for 'seconds_buffer', corresponding to %lu seconds.\n", (total_bytes / (1024.0f * 1024.0f * 1024.0f)), seconds_buffer.capacity);
-        seconds_buffer.data = (char*) malloc(total_bytes);
-        if(!seconds_buffer.data){
+        vm->seconds_buffer.capacity = vm->seconds_per_file * (desired_seconds_in_buffer / vm->seconds_per_file);
+        size_t total_bytes = vm->bytes_per_second * vm->seconds_buffer.capacity;
+       
+        sprintf(vm->log_message, "read_next_second_from_buffer: will allocate %.4f GiB for 'seconds_buffer', "
+            "corresponding to %lu seconds.", (total_bytes / (1024.0f * 1024.0f * 1024.0f)), vm->seconds_buffer.capacity);
+        logger_message( vm->log, vm->log_message );
+        
+        vm->seconds_buffer.data = (char*) malloc(total_bytes);
+        if(!(vm->seconds_buffer.data)){
             fprintf(stderr, "Error allocating memory for 'seconds_buffer'.\n");
             exit(1);
         }
-        seconds_buffer.current_time_idx = vm->vcs_metadata->common_timestep_indices[0];
-        
-        printf("Timestep indices are: ");
-        for(int i = 0; i < vm->vcs_metadata->num_common_timesteps; i++) printf("%d, ", vm->vcs_metadata->common_timestep_indices[i]);
-        printf("\n");
-        printf("Voltage block size: %lu, voltage blocks per second %lu\n", vm->vcs_metadata->voltage_block_size_bytes, vm->vcs_metadata->num_voltage_blocks_per_second);
-        printf("Expected voltage data size: %lu\n", vm->vcs_metadata->expected_voltage_data_file_size_bytes - vm->vcs_metadata->data_file_header_size_bytes -vm->vcs_metadata->delay_block_size_bytes);
-        
+        vm->seconds_buffer.current_timestep_idx = vm->vcs_metadata->common_timestep_indices[0];
     }
-    // TODO: do not support gps_second_count != 1, because the mechanism to refill the buffer
-    // might be more complicated
-    if(seconds_buffer.count == seconds_buffer.size){
-        // buffer is empty, refill it
-        // TODO: check for read sizes less than buffer size
-        // TODO: use read file function in mwalib next
-        size_t seconds_to_read = seconds_buffer.capacity < seconds_buffer.n_remaining_seconds ? \
-            seconds_buffer.capacity : seconds_buffer.n_remaining_seconds;
-        size_t start_timestep_idx = seconds_buffer.current_timestep_idx;
+
+    if(vm->seconds_buffer.count == vm->seconds_buffer.size){
+        // All seconds in the buffer have been used. The buffer is empty, refill it
+        size_t seconds_to_read = vm->seconds_buffer.capacity < vm->seconds_buffer.n_remaining_seconds ? \
+            vm->seconds_buffer.capacity : vm->seconds_buffer.n_remaining_seconds;
+        size_t start_timestep_idx = vm->seconds_buffer.current_timestep_idx;
         size_t n_timesteps_to_read = seconds_to_read / vm->seconds_per_file;
-        size_t end_timestep_idx = seconds_buffer.current_timestep_idx + n_timesteps_to_read;
+        size_t end_timestep_idx = vm->seconds_buffer.current_timestep_idx + n_timesteps_to_read;
         size_t read_size = ((size_t) vm->bytes_per_second) * vm->seconds_per_file;
-        
-        printf("Seconds to read is %lu, read_size is %lu\n", seconds_to_read, read_size);
+        logger_start_stopwatch( vm->log, "read-seconds", true);
+        // sprintf(vm->log_message, "read_next_second_from_buffer: will now read %lu seconds into the buffer.\n", seconds_to_read);
+        logger_message( vm->log, vm->log_message );
+        // Read multiple (file) timesteps in parallel using OpenMP
         #pragma omp parallel for schedule(static)
         for(size_t timestep_idx = start_timestep_idx; timestep_idx < end_timestep_idx; timestep_idx += 1){
-            printf("Thread %d of %d reading sec %lu (sec per file is %d)\n", omp_get_thread_num(), omp_get_num_threads(), sec_idx, vm->seconds_per_file);
             if(mwalib_voltage_context_read_file(vm->vcs_context,
                                          timestep_idx,
                                          voltage_coarse_chan_index,
-                                         seconds_buffer.data + read_size * (timestep_idx - start_timestep_idx), read_size,
+                                         vm->seconds_buffer.data + read_size * (timestep_idx - start_timestep_idx), read_size,
                                          vm->error_message, ERROR_MESSAGE_LEN)!= MWALIB_SUCCESS){
                  fprintf( stderr, "error: mwalib_voltage_context_read_file failed: %s", vm->error_message );
                  exit(EXIT_FAILURE);
             }
         }
-        seconds_buffer.count = 0u;
-        seconds_buffer.size = seconds_to_read;
-        seconds_buffer.n_remaining_seconds -= seconds_to_read;
-        seconds_buffer.current_time_idx += n_timesteps_to_read;
+        vm->seconds_buffer.count = 0u;
+        vm->seconds_buffer.size = seconds_to_read;
+        vm->seconds_buffer.n_remaining_seconds -= seconds_to_read;
+        vm->seconds_buffer.current_timestep_idx += n_timesteps_to_read;
+        logger_stop_stopwatch( vm->log, "read-seconds");
     }
 
-    char *source = seconds_buffer.data + seconds_buffer.count * vm->bytes_per_second;
-    // read the next seocond
+    char *source = vm->seconds_buffer.data + vm->seconds_buffer.count * vm->bytes_per_second;
+    // read the next seocond into the actual VCSBeam buffer.
     memcpy(buffer_ptr, source, vm->bytes_per_second);
-    seconds_buffer.count += 1;
+    vm->seconds_buffer.count += 1;
 }
 
 
@@ -1077,15 +1068,30 @@ vm_error vmReadNextSecond( vcsbeam_context *vm )
             vm->error_message,
             ERROR_MESSAGE_LEN);
     */
-    read_from_buffer(
-                vm,
+    if(vm->use_seconds_buffer){
+        // Use underlying buffering mechanism to read multiple seconds in memory, in parallel.
+        read_next_second_from_buffer(
+            vm,
+            coarse_chan_idx,
+            vm->v->read_ptr,
+            vm->v->read_size,
+            vm->error_message,
+            ERROR_MESSAGE_LEN);
+    }else{
+        // No buffering, just read the next second from the file.
+        if (mwalib_voltage_context_read_second(
+                vm->vcs_context,
                 gps_second,
                 1,
                 coarse_chan_idx,
                 vm->v->read_ptr,
                 vm->v->read_size,
                 vm->error_message,
-                ERROR_MESSAGE_LEN);
+                ERROR_MESSAGE_LEN ) != MWALIB_SUCCESS) {
+            fprintf( stderr, "error: mwalib_voltage_context_read_file failed: %s", vm->error_message );
+            exit(EXIT_FAILURE);
+        }
+    }
 
     logger_stop_stopwatch( vm->log, "read" );
 

--- a/src/metadata.c
+++ b/src/metadata.c
@@ -153,7 +153,6 @@ vcsbeam_context *vmInit( bool use_mpi, int seconds_buffer_size )
     logger_add_stopwatch( vm->log, "download",  "Downloading the data to the host" );
     logger_add_stopwatch( vm->log, "splice",    "Splicing coarse channels together" );
     logger_add_stopwatch( vm->log, "write",     "Writing out data to file" );
-    logger_add_stopwatch( vm->log, "init-buffer",     "Initialise the memory buffer." );
     logger_add_stopwatch( vm->log, "read-seconds",     "Reading seconds into memory buffer." );
     
 

--- a/src/metadata.c
+++ b/src/metadata.c
@@ -12,6 +12,10 @@
 
 #include "vcsbeam.h"
 
+#ifdef _OPENMP
+#include <omp.h>
+#endif
+
 #include "gpu_macros.h"
 
 /**
@@ -928,21 +932,29 @@ void vmPushChunk( vcsbeam_context *vm )
     And whether that will improve the I/O performance of the program. At first, it is all
     sequential. That is, a buffer is allocated, and populated when emptied, and consumed by
     vmReadNextSecond transparently.
+
+    We are making the assumption that seconds are processed contiguously. That is,
+    the sequence of GPS seconds that is passed to vmReadNextSeconds corresponds to the
+    sequence defined by the files referenced in `common_timestep_indices`.
 */
 
 struct {
+    // where the data is stored.
     char *data;
-    uint64_t current_gps_second;
-    uint64_t n_remaining_gps_seconds;
+    // next timestep file to read.
+    uint64_t current_timestep_idx;
+    // keeps track of the number of remaining seconds that need to be processed.
+    uint64_t n_remaining_seconds;
+    // number of seconds in the buffer that have been already processed.
     uint64_t count;
+    // number of seconds currently stored in the buffer.
     uint64_t size;
+    // how many seconds can the buffer store.
     uint64_t capacity;
 } seconds_buffer = {NULL, 0u, 0u, 0u, 0u, 0u};
 
 
-void read_from_buffer(vcsbeam_context *vm,
-                    unsigned long gps_second_start,
-                    size_t gps_second_count,
+void read_second_from_buffer(vcsbeam_context *vm,
                     size_t voltage_coarse_chan_index,
                     signed char *buffer_ptr,
                     size_t buffer_len,
@@ -951,27 +963,33 @@ void read_from_buffer(vcsbeam_context *vm,
     
     if(seconds_buffer.data == NULL){
         // Initialise the structure
-        //unsigned int nfiletimes;          // The number of "file" timesteps
-        seconds_buffer.n_remaining_gps_seconds = vm->nfiletimes * vm->seconds_per_file;
-        printf("CDP DEBUG: n_remaining_gps_seconds is set to: %lu, "
+        // Initially, all seconds must still be processed.
+        seconds_buffer.n_remaining_seconds = vm->nfiletimes * vm->seconds_per_file;
+        printf("CDP DEBUG: n_remaining_seconds is set to: %lu, "
             "with nfiletimes = %lu and seconds per file = %lu\n",
-            seconds_buffer.n_remaining_gps_seconds, vm->nfiletimes, vm->seconds_per_file);
+            seconds_buffer.n_remaining_seconds, vm->nfiletimes, vm->seconds_per_file);
         // the following must be greater than the number of seconds
         // in each file.
         // TODO: check gps_second_count is less than buffer size
         // TODO: find a clever way of doing this.
         size_t desired_seconds_in_buffer = 64;
         // this will ensure each file is read in full
-        size_t total_seconds = vm->seconds_per_file * (desired_seconds_in_buffer / vm->seconds_per_file);
-        size_t total_bytes = vm->bytes_per_second * total_seconds;
-        seconds_buffer.capacity = total_seconds;
-        printf("Will allocate %.4f GiB for 'seconds_buffer', corresponding to %lu seconds.\n", (total_bytes / (1024.0f * 1024.0f * 1024.0f)), total_seconds);
+        seconds_buffer.capacity = vm->seconds_per_file * (desired_seconds_in_buffer / vm->seconds_per_file);
+        size_t total_bytes = vm->bytes_per_second * seconds_buffer.capacity;
+        printf("Will allocate %.4f GiB for 'seconds_buffer', corresponding to %lu seconds.\n", (total_bytes / (1024.0f * 1024.0f * 1024.0f)), seconds_buffer.capacity);
         seconds_buffer.data = (char*) malloc(total_bytes);
-        seconds_buffer.current_gps_second = gps_second_start;
         if(!seconds_buffer.data){
             fprintf(stderr, "Error allocating memory for 'seconds_buffer'.\n");
             exit(1);
         }
+        seconds_buffer.current_time_idx = vm->vcs_metadata->common_timestep_indices[0];
+        
+        printf("Timestep indices are: ");
+        for(int i = 0; i < vm->vcs_metadata->num_common_timesteps; i++) printf("%d, ", vm->vcs_metadata->common_timestep_indices[i]);
+        printf("\n");
+        printf("Voltage block size: %lu, voltage blocks per second %lu\n", vm->vcs_metadata->voltage_block_size_bytes, vm->vcs_metadata->num_voltage_blocks_per_second);
+        printf("Expected voltage data size: %lu\n", vm->vcs_metadata->expected_voltage_data_file_size_bytes - vm->vcs_metadata->data_file_header_size_bytes -vm->vcs_metadata->delay_block_size_bytes);
+        
     }
     // TODO: do not support gps_second_count != 1, because the mechanism to refill the buffer
     // might be more complicated
@@ -979,32 +997,36 @@ void read_from_buffer(vcsbeam_context *vm,
         // buffer is empty, refill it
         // TODO: check for read sizes less than buffer size
         // TODO: use read file function in mwalib next
-        size_t seconds_to_read = seconds_buffer.capacity < seconds_buffer.n_remaining_gps_seconds ? \
-            seconds_buffer.capacity : seconds_buffer.n_remaining_gps_seconds;
-        size_t start_gps = seconds_buffer.current_gps_second;
-        size_t end_gps = seconds_buffer.current_gps_second + seconds_to_read;
-        size_t read_size = vm->bytes_per_second * vm->seconds_per_file;
-
-        #pragma omp parallel for schedule(static) num_threads((seconds_to_read/vm->seconds_per_file))
-        for(size_t sec_idx = start_gps; sec_idx < end_gps; sec_idx += vm->seconds_per_file){
-            // We are assuming that the seconds_to_read is always a integer multiple of seconds_per_file!
-            if(mwalib_voltage_context_read_second(vm->vcs_context, sec_idx, vm->seconds_per_file,
-                    voltage_coarse_chan_index, seconds_buffer.data + read_size * (sec_idx - start_gps), read_size,
-                    vm->error_message, ERROR_MESSAGE_LEN ) != MWALIB_SUCCESS){
-                fprintf( stderr, "error: mwalib_voltage_context_read_file failed: %s", vm->error_message );
-                exit(EXIT_FAILURE);
+        size_t seconds_to_read = seconds_buffer.capacity < seconds_buffer.n_remaining_seconds ? \
+            seconds_buffer.capacity : seconds_buffer.n_remaining_seconds;
+        size_t start_timestep_idx = seconds_buffer.current_timestep_idx;
+        size_t n_timesteps_to_read = seconds_to_read / vm->seconds_per_file;
+        size_t end_timestep_idx = seconds_buffer.current_timestep_idx + n_timesteps_to_read;
+        size_t read_size = ((size_t) vm->bytes_per_second) * vm->seconds_per_file;
+        
+        printf("Seconds to read is %lu, read_size is %lu\n", seconds_to_read, read_size);
+        #pragma omp parallel for schedule(static)
+        for(size_t timestep_idx = start_timestep_idx; timestep_idx < end_timestep_idx; timestep_idx += 1){
+            printf("Thread %d of %d reading sec %lu (sec per file is %d)\n", omp_get_thread_num(), omp_get_num_threads(), sec_idx, vm->seconds_per_file);
+            if(mwalib_voltage_context_read_file(vm->vcs_context,
+                                         timestep_idx,
+                                         voltage_coarse_chan_index,
+                                         seconds_buffer.data + read_size * (timestep_idx - start_timestep_idx), read_size,
+                                         vm->error_message, ERROR_MESSAGE_LEN)!= MWALIB_SUCCESS){
+                 fprintf( stderr, "error: mwalib_voltage_context_read_file failed: %s", vm->error_message );
+                 exit(EXIT_FAILURE);
             }
         }
         seconds_buffer.count = 0u;
         seconds_buffer.size = seconds_to_read;
-        seconds_buffer.n_remaining_gps_seconds -= seconds_to_read;
+        seconds_buffer.n_remaining_seconds -= seconds_to_read;
+        seconds_buffer.current_time_idx += n_timesteps_to_read;
     }
 
     char *source = seconds_buffer.data + seconds_buffer.count * vm->bytes_per_second;
-    memcpy(buffer_ptr, source, vm->bytes_per_second * gps_second_count);
-    seconds_buffer.count += gps_second_count;
-    // we are assuming seconds are read sequentially!
-    seconds_buffer.current_gps_second += gps_second_count;
+    // read the next seocond
+    memcpy(buffer_ptr, source, vm->bytes_per_second);
+    seconds_buffer.count += 1;
 }
 
 


### PR DESCRIPTION
This is a first implementation of an extra buffer between vcsbeam's `vmReadNextSecond` and MWALIB's `mwalib_voltage_context_read_second`. At this point it is still very much experimental, but I have tested it with the Crab dataset and it works. But it is too small to see any benefit.

What has been implemented:

- An extra buffer to read multiple seconds in memory at once.
- Files, especially MWAX ones, are read in one go.
- Parallelisation through OpenMP of reading the next `seconds_to_read` seconds.