### PR TITLE
Incoherent memory fix

### DIFF
--- a/app/make_mwa_incoh_beam.c
+++ b/app/make_mwa_incoh_beam.c
@@ -183,8 +183,6 @@ int main(int argc, char **argv)
     // Clean up memory associated with mwalib
     destroy_vcsbeam_context( vm );
 
-    logger_timed_message( vm->log, "Exiting successfully" );
-
     return EXIT_SUCCESS;
 }
 

--- a/src/calibration.c
+++ b/src/calibration.c
@@ -1061,10 +1061,13 @@ void free_calibration( calibration *cal )
     if (cal->flags_file != NULL)
         free( cal->flags_file );
 
-    int i;
-    for (i = 0; i < cal->nflags; i++)
+    if (cal->flagged_tilenames != NULL)
     {
-        free( cal->flagged_tilenames[i] );
+        int i;
+        for (i = 0; i < cal->nflags; i++)
+        {
+            free( cal->flagged_tilenames[i] );
+        }
+        free( cal->flagged_tilenames );
     }
-    free( cal->flagged_tilenames );
 }

--- a/src/metadata.c
+++ b/src/metadata.c
@@ -361,10 +361,7 @@ void destroy_vcsbeam_context( vcsbeam_context *vm )
     if (vm->decs_degs != NULL)  free( vm->decs_degs );
 
     // Calibration
-    if (vm->cal != NULL)
-    {
-        free_calibration( &vm->cal );
-    }
+    free_calibration( &vm->cal );
 
     // Filters
     if (vm->analysis_filter != NULL)

--- a/src/metadata.c
+++ b/src/metadata.c
@@ -346,7 +346,10 @@ void destroy_vcsbeam_context( vcsbeam_context *vm )
     if (vm->decs_degs != NULL)  free( vm->decs_degs );
 
     // Calibration
-    free_calibration( &vm->cal );
+    if (vm->cal != NULL)
+    {
+        free_calibration( &vm->cal );
+    }
 
     // Filters
     if (vm->analysis_filter != NULL)


### PR DESCRIPTION
So I found two different points of segfault errors when running the clean up script `destroy_vcsbeam_context` in incoherent beamforming. One is that it is accessing`cal->flagged_tilenames` which is NULL when running incoherent beamforming. A second change is removing access to log after they are removed in `destroy_vcsbeam_context`. This change is in-line with how it is done in the coherent beamforming.